### PR TITLE
Shiftypi

### DIFF
--- a/cplds/mojo-ise/src/mojo.ucf
+++ b/cplds/mojo-ise/src/mojo.ucf
@@ -77,7 +77,7 @@ NET "cru_base<3>" LOC = P105 | IOSTANDARD = LVCMOS33 | PULLDOWN;
 
 
 // Transciever enable signal outputs
-NET "tipi_dsr_out" LOC = P100 | IOSTANDARD = LVCMOS33;
+NET "tipi_dbus_oe" LOC = P100 | IOSTANDARD = LVCMOS33;
 
 // Meant to be inputs to the raspberry pi as a data bus
 NET "rpi_d<0>" LOC = P50 | IOSTANDARD = LVCMOS33;

--- a/cplds/mojo-ise/src/mojo.ucf
+++ b/cplds/mojo-ise/src/mojo.ucf
@@ -69,7 +69,7 @@ NET "ti_cruclk" LOC = P95 | IOSTANDARD = LVCMOS33;
 NET "ti_reset" LOC = P97 | IOSTANDARD = LVCMOS33;
 
 // USER CRU Nibble
-// It will be easier to ground these on PULLUPs with headers.
+// It will be easier to set these on PULLUPs with headers.
 NET "cru_base<0>" LOC = P101 | IOSTANDARD = LVCMOS33 | PULLDOWN;
 NET "cru_base<1>" LOC = P102 | IOSTANDARD = LVCMOS33 | PULLDOWN;
 NET "cru_base<2>" LOC = P104 | IOSTANDARD = LVCMOS33 | PULLDOWN;
@@ -77,8 +77,6 @@ NET "cru_base<3>" LOC = P105 | IOSTANDARD = LVCMOS33 | PULLDOWN;
 
 
 // Transciever enable signal outputs
-NET "tipi_data_out" LOC = P111 | IOSTANDARD = LVCMOS33;
-NET "tipi_control_out" LOC = P112 | IOSTANDARD = LVCMOS33;
 NET "tipi_dsr_out" LOC = P100 | IOSTANDARD = LVCMOS33;
 
 // Meant to be inputs to the raspberry pi as a data bus
@@ -111,4 +109,8 @@ NET "dsr_d<5>" LOC = P8 | IOSTANDARD = LVCMOS33;
 NET "dsr_d<6>" LOC = P9 | IOSTANDARD = LVCMOS33;
 NET "dsr_d<7>" LOC = P10 | IOSTANDARD = LVCMOS33;
 
-
+// Shift register inputs from RPi
+NET rpi_dclk LOC = P23 | IOSTANDARD = LVCMOS33;
+NET rpi_cclk LOC = P24 | IOSTANDARD = LVCMOS33;
+NET rpi_sdata LOC = P26 | IOSTANDARD = LVCMOS33;
+NET rpi_le LOC = P27 | IOSTANDARD = LVCMOS33;

--- a/cplds/mojo-ise/src/mojo_top.v
+++ b/cplds/mojo-ise/src/mojo_top.v
@@ -19,13 +19,6 @@ module mojo_top(
     output avr_rx, // AVR Rx => FPGA Tx
     input avr_rx_busy, // AVR Rx buffer full
      
-    // Control OE* on a bus transmitter to allow RPi data on TI data bus.
-    output tipi_data_out,
-    // Control OE* on a bus transmitter to allow RPi control signals on TI data bus.
-    output tipi_control_out,
-    // Control OE* on a bus transmitter to allow DSR ROM on TI data bus.
-    output tipi_dsr_out,
-     
     // TI address bus. bit 0 is MSB per TI numbering.
     input [0:15]ti_a,
     // TI data bus inputs. bit 0 is MSB.
@@ -43,12 +36,21 @@ module mojo_top(
     // TI Reset (active low)
     input ti_reset,
     
+	 // Inputs for data and control registers from RPi
+	 input rpi_cclk,
+	 input rpi_dclk,
+	 input rpi_sdata,
+	 input rpi_le,
+	 
     // Data output to RPi latched from 0x5fff
     output [7:0]rpi_d,
     // Control signal output to RPi latched from 0x5ffd
     output [7:0]rpi_s,
-	 // DSR ROM Data output from 0x4000 to 0x5ff8
-	 output [0:7]dsr_d
+	 // DSR ROM Data output from 0x4000 to 0x5ff8, or RPi registers
+	 output [0:7]dsr_d,
+
+    // Control OE* on a bus transmitter to allow DSR ROM or RPi registers on TI data bus.
+    output tipi_dsr_out
 );
 
 reg [0:7] dsr_data_rom [0:8191];
@@ -63,6 +65,10 @@ wire a15;
 
 wire rst = ~rst_n; // make reset active high
 
+wire tipi_data_out;
+wire tipi_control_out;
+
+
 // a CRU bit to act as device-enable
 reg crubit_q;
 
@@ -70,6 +76,12 @@ reg crubit_q;
 reg [7:0] data_q;
 // latched control channel
 reg [7:0] control_q;
+
+// shift register signals from RPi
+reg [7:0] rdata_q;
+reg [7:0] rdata_latch;
+reg [7:0] rcontrol_q;
+reg [7:0] rcontrol_latch;
 
 // these signals should be high-z when not used
 assign spi_miso = 1'bz;
@@ -107,12 +119,23 @@ always @(posedge clk) begin
   dsr_q <= dsr_data_rom[rom_idx];
 end
 
+always @(posedge rpi_cclk) begin
+  if (rpi_le) rcontrol_latch <= rcontrol_q;
+  else rcontrol_q <= { rcontrol_q[6:0], rpi_sdata };
+end
+
+always @(posedge rpi_dclk) begin
+  if (rpi_le) rdata_latch <= rdata_q;
+  else rdata_q <= { rdata_q[6:0], rpi_sdata };
+end
+
 assign dsr_d = dsr_q;
 
 assign rpi_d = data_q;
 assign rpi_s = control_q;
 
-assign led[7:1] = control_q[6:0];
-assign led[0] = crubit_q;
+// assign led[7:1] = control_q[6:0];
+// assign led[0] = crubit_q;
+assign led = rdata_latch;
 
 endmodule

--- a/dsr/python/test1.py
+++ b/dsr/python/test1.py
@@ -4,12 +4,20 @@ import sys
 import time
 
 from tipi.TipiMessage import TipiMessage
+from tipi.TipiPorts import TipiPorts
 
 tipi_io = TipiMessage()
+tipi_ports = TipiPorts()
 
-bytes = tipi_io.receive()
+start = time.time()
 
-for byte in bytes:
-  print '{0:0>2x} '.format(byte)
-  sys.stdout.flush()
+for i in range(0,8192):
+    time.sleep(0.001)
+    tipi_ports.setRD(0)
+    time.sleep(0.001)
+    tipi_ports.setRD(i)
+
+stop = time.time()
+
+print stop - start
 

--- a/dsr/python/test1.py
+++ b/dsr/python/test1.py
@@ -12,9 +12,6 @@ tipi_ports = TipiPorts()
 start = time.time()
 
 for i in range(0,8192):
-    time.sleep(0.001)
-    tipi_ports.setRD(0)
-    time.sleep(0.001)
     tipi_ports.setRD(i)
 
 stop = time.time()

--- a/dsr/python/tipi/TipiPorts.py
+++ b/dsr/python/tipi/TipiPorts.py
@@ -25,24 +25,11 @@ class TipiPorts(object):
         self.__TC7 = 7
 
         self.__TC_BITS = [self.__TC0, self.__TC1, self.__TC2, self.__TC3, self.__TC4, self.__TC5, self.__TC6, self.__TC7]
- 
-        self.__RD0 = 11
-        self.__RD1 = 0
-        self.__RD2 = 5
-        self.__RD3 = 6
-        self.__RD4 = 13
-        self.__RD5 = 19
-        self.__RD6 = 26
-        self.__RD7 = 21
 
-        self.__RD_BITS = [self.__RD0, self.__RD1, self.__RD2, self.__RD3, self.__RD4, self.__RD5, self.__RD6, self.__RD7]
-
-        self.__RC0 = 1
-        self.__RC1 = 12
-        self.__RC2 = 16
-        self.__RC3 = 20
-
-        self.__RC_BITS = [self.__RC0, self.__RC1, self.__RC2, self.__RC3]
+        self.__R_CCLK = 19
+        self.__R_DCLK = 26
+        self.__R_SDATA = 13
+        self.__R_LE = 6
  
         GPIO.setmode(GPIO.BCM) 
         GPIO.setwarnings(True)
@@ -50,8 +37,10 @@ class TipiPorts(object):
         GPIO.setup(self.__TD_BITS, GPIO.IN)
         GPIO.setup(self.__TC_BITS, GPIO.IN)
 
-        GPIO.setup(self.__RD_BITS, GPIO.OUT)
-        GPIO.setup(self.__RC_BITS, GPIO.OUT)
+        GPIO.setup(self.__R_CCLK, GPIO.OUT)
+        GPIO.setup(self.__R_DCLK, GPIO.OUT)
+        GPIO.setup(self.__R_SDATA, GPIO.OUT)
+        GPIO.setup(self.__R_LE, GPIO.OUT)
 
 	self.setRD(0)
 	self.setRC(0)
@@ -75,26 +64,19 @@ class TipiPorts(object):
         return byte
 
     #
-    # Write a byte of to a set of 8 output pins
+    # Write a byte of to an 8 bit output register selected by clk
     #
-    def __writeByteToBits(self, byte, bits):
-        GPIO.output(bits[0], byte & 0x80)
-        GPIO.output(bits[1], byte & 0x40)
-        GPIO.output(bits[2], byte & 0x20)
-        GPIO.output(bits[3], byte & 0x10)
-        GPIO.output(bits[4], byte & 0x08)
-        GPIO.output(bits[5], byte & 0x04)
-        GPIO.output(bits[6], byte & 0x02)
-        GPIO.output(bits[7], byte & 0x01)
-
-    #
-    # Write a least significant 4 bits of a byte to a set of 4 output pins
-    #
-    def __writeNibbleToBits(self, byte, bits):
-        GPIO.output(bits[0], byte & 0x08)
-        GPIO.output(bits[1], byte & 0x04)
-        GPIO.output(bits[2], byte & 0x02)
-        GPIO.output(bits[3], byte & 0x01)
+    def __writeByteToRegister(self, byte, clk):
+        for i in range(0,8):
+            GPIO.output(clk, 0)
+            GPIO.output(self.__R_SDATA, (byte >> i) & 0x01)
+            GPIO.output(clk, 1)
+        
+        GPIO.output(clk, 0)
+        GPIO.output(self.__R_LE, 1)
+        GPIO.output(clk, 1)
+        GPIO.output(self.__R_LE, 0)
+        GPIO.output(clk, 0)
 
     # Read TI_DATA
     def getTD(self):
@@ -106,9 +88,9 @@ class TipiPorts(object):
 
     # Write RPI_DATA
     def setRD(self, value):
-        self.__writeByteToBits(value, self.__RD_BITS)
+        self.__writeByteToRegister(value, self.__R_DCLK)
 
     # Write RPI_CONTROL
     def setRC(self, value):
-        self.__writeNibbleToBits(value, self.__RC_BITS)
+        self.__writeByteToRegister(value, self.__R_CCLK)
 

--- a/dsr/python/tipi/TipiPorts.py
+++ b/dsr/python/tipi/TipiPorts.py
@@ -67,7 +67,7 @@ class TipiPorts(object):
     # Write a byte of to an 8 bit output register selected by clk
     #
     def __writeByteToRegister(self, byte, clk):
-        for i in range(0,8):
+        for i in reversed(range(0,8)):
             GPIO.output(clk, 0)
             GPIO.output(self.__R_SDATA, (byte >> i) & 0x01)
             GPIO.output(clk, 1)


### PR DESCRIPTION
Using shift registers for output from Raspberry PI. 4 wires provides 16 bits of output. 
  rpi_cclk : control output serial clock
  rpi_dclk : data output serial clock
  rpi_sdata : serial data
  rpi_le : latch enable / publish data to parallel output.

sdata and le are shared since there is only one thread outputing data. Which register it goes into is controlled by which clk is used.  At least I'm able to make it work like that in verilog. 