### PR TITLE
Native gpio

### DIFF
--- a/dsr/python/ResetHandler.py
+++ b/dsr/python/ResetHandler.py
@@ -1,0 +1,37 @@
+import os
+import signal
+import time
+import socket
+import threading
+import logging
+
+logger = logging.getLogger("tipi")
+
+def createResetListener():
+    t = threading.Thread(target=waitForReset)
+    t.start()
+    logger.info("reset listener started.")
+
+def waitForReset():
+    s = socket.socket()
+    host = 'localhost'
+    port = 9903
+    binding = True
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.bind((host, port))
+
+    s.listen(0)
+
+    c, addr = s.accept()
+    logger.info("responding to reset interrupt")
+    c.send("tipi service resetting.")
+    try:
+        c.shutdown(socket.SHUT_RDWR)
+        c.close()
+    except Exception as e:
+        pass
+
+    logger.info("terminating...")
+    os.kill(os.getpid(), signal.SIGTERM)
+   
+

--- a/dsr/python/TipiWatchDog.py
+++ b/dsr/python/TipiWatchDog.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python2
+import RPi.GPIO as GPIO 
+import sys
+import time
+import socket
+
+class TipiWatchDog(object):
+
+    def __init__(self):
+        self.__RESET = 5
+
+        GPIO.setmode(GPIO.BCM) 
+        GPIO.setwarnings(False)
+
+        GPIO.setup(self.__RESET, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+        # Do not proceed unless the reset signal has turned off
+        # attempt to prevent restart storm in systemd
+        
+        while GPIO.input(self.__RESET) != 1:
+            print "waiting for reset to complete."
+            pass
+        GPIO.add_event_detect(self.__RESET, GPIO.FALLING, callback=onReset, bouncetime=100)
+        print "GPIO initialized."
+
+
+def onReset(channel):
+    print "responding to reset interrupt"
+    s = socket.socket()
+    s.connect(('localhost',9903))
+    s.close()
+    
+
+watchDog = TipiWatchDog()
+
+print "Waiting for RESET event..."
+while True:
+    time.sleep(1);
+
+

--- a/dsr/python/fileserver.py
+++ b/dsr/python/fileserver.py
@@ -14,6 +14,7 @@ from tinames import tinames
 from SpecialFiles import SpecialFiles
 from Pab import *
 from RawExtensions import RawExtensions
+from ResetHandler import createResetListener
 
 #
 # Setup logging
@@ -22,7 +23,7 @@ logging.basicConfig(level=logging.DEBUG,
                     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
                     datefmt='%m-%d %H:%M:%S',
                     filename='/var/log/tipi/tipi.log',
-                    filemode='w')
+                    filemode='a')
 
 logger = logging.getLogger('tipi')
 
@@ -316,6 +317,8 @@ def createFileReadRecord(path,recordNumber):
 ## 
 ## MAIN
 ##
+
+createResetListener()
 
 tipi_io = TipiMessage()
 specialFiles = SpecialFiles(tipi_io)

--- a/dsr/python/libtipi/.gitignore
+++ b/dsr/python/libtipi/.gitignore
@@ -1,0 +1,2 @@
+build
+env

--- a/dsr/python/libtipi/README.md
+++ b/dsr/python/libtipi/README.md
@@ -9,7 +9,7 @@ Using C instead of RPi.GPIO should be able to outpace the TI-99/4A, where the py
 library is relatively slow. Benchmarks from 2015 showed RPi.GPIO operating at 70 Khz, 
 where Native C operated at 22 Mhz. 
 
-With the use of shift registers, we go from 16 IOs per byte to 56 IOs per byte. 
+With the use of shift registers, we go from 8 IOs per byte to 28 IOs per byte. 
 Consequently, the need for performance is real.
 
 # Building

--- a/dsr/python/libtipi/README.md
+++ b/dsr/python/libtipi/README.md
@@ -1,0 +1,46 @@
+
+# Native C to python interface for tipi gpio
+
+This library should encapsulate the GPIO routines required for interacting with the 
+shift registers and data latches that are in the TIPI hardware, from the Raspberry PI
+side of the interface. 
+
+Using C instead of RPi.GPIO should be able to outpace the TI-99/4A, where the python
+library is relatively slow. Benchmarks from 2015 showed RPi.GPIO operating at 70 Khz, 
+where Native C operated at 22 Mhz. 
+
+With the use of shift registers, we go from 16 IOs per byte to 56 IOs per byte. 
+Consequently, the need for performance is real.
+
+# Building
+
+```
+virtualenv env
+. env/bin/activate
+pip install -r requirements.txt
+python setup.py install
+```
+
+# Usage
+
+Example python usage of the library.
+
+```
+import tipiports
+
+# initialize GPIO pins for TIPI
+tipiports.initGpio()
+
+# read control byte from TI
+print tipiports.getTC()
+
+# read data byte from TI
+print tipiports.getTD()
+
+# set data byte from RPi
+tipiports.setRD()
+
+# set control byte from RPi
+tipiports.setRC()
+```
+

--- a/dsr/python/libtipi/gpio.h
+++ b/dsr/python/libtipi/gpio.h
@@ -1,0 +1,88 @@
+
+#ifndef GPIO_BASE
+
+//
+//  How to access GPIO registers from C-code on the Raspberry-Pi
+//  Example program
+//  15-January-2012
+//  Dom and Gert
+//  Revised: 15-Feb-2013
+ 
+ 
+// Access from ARM Running Linux
+ 
+#ifndef PI2
+#define BCM2708_PERI_BASE        0x3F000000
+#else
+#define BCM2708_PERI_BASE        0x20000000
+#endif
+#define GPIO_BASE                (BCM2708_PERI_BASE + 0x200000) /* GPIO controller */
+ 
+ 
+#include <stdio.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+ 
+#define PAGE_SIZE (4*1024)
+#define BLOCK_SIZE (4*1024)
+ 
+int  mem_fd;
+void *gpio_map;
+ 
+// I/O access
+volatile unsigned *gpio;
+ 
+ 
+// GPIO setup macros. Always use INP_GPIO(x) before using OUT_GPIO(x) or SET_GPIO_ALT(x,y)
+#define INP_GPIO(g) *(gpio+((g)/10)) &= ~(7<<(((g)%10)*3))
+#define OUT_GPIO(g) *(gpio+((g)/10)) |=  (1<<(((g)%10)*3))
+#define SET_GPIO_ALT(g,a) *(gpio+(((g)/10))) |= (((a)<=3?(a)+4:(a)==4?3:2)<<(((g)%10)*3))
+ 
+#define GPIO_SET *(gpio+7)  // sets   bits which are 1 ignores bits which are 0
+#define GPIO_CLR *(gpio+10) // clears bits which are 1 ignores bits which are 0
+ 
+#define GET_GPIO(g) (*(gpio+13)&(1<<g)) // 0 if LOW, (1<<g) if HIGH
+ 
+#define GPIO_PULL *(gpio+37) // Pull up/pull down
+#define GPIO_PULLCLK0 *(gpio+38) // Pull up/pull down clock
+
+void setup_io(void);
+
+//
+// Set up a memory regions to access GPIO
+//
+void setup_io(void)
+{
+   /* open /dev/mem */
+   if ((mem_fd = open("/dev/gpiomem", O_RDWR|O_SYNC) ) < 0) {
+      printf("can't open /dev/gpiomem \n");
+      exit(-1);
+   }
+ 
+   /* mmap GPIO */
+   gpio_map = mmap(
+      NULL,             //Any adddress in our space will do
+      BLOCK_SIZE,       //Map length
+      PROT_READ|PROT_WRITE,// Enable reading & writting to mapped memory
+      MAP_SHARED,       //Shared with other processes
+      mem_fd,           //File to map
+      GPIO_BASE         //Offset to GPIO peripheral
+   );
+ 
+   close(mem_fd); //No need to keep mem_fd open after mmap
+ 
+   if (gpio_map == MAP_FAILED) {
+      printf("mmap error %d\n", (int)gpio_map);//errno also set!
+      exit(-1);
+   }
+ 
+   // Always use volatile pointer!
+   gpio = (volatile unsigned *)gpio_map;
+ 
+ 
+} // setup_io
+
+#endif 
+

--- a/dsr/python/libtipi/requirements.txt
+++ b/dsr/python/libtipi/requirements.txt
@@ -1,0 +1,4 @@
+appdirs==1.4.3
+packaging==16.8
+pyparsing==2.2.0
+six==1.10.0

--- a/dsr/python/libtipi/setup.py
+++ b/dsr/python/libtipi/setup.py
@@ -1,0 +1,8 @@
+
+from distutils.core import setup, Extension
+
+moduletipi = Extension('tipiports', sources = ['tipiports.c'])
+
+setup (name = 'tipiports', version = '1.0', description = 'low level tipi io', ext_modules = [moduletipi])
+
+

--- a/dsr/python/libtipi/tipiports.c
+++ b/dsr/python/libtipi/tipiports.c
@@ -1,0 +1,175 @@
+
+#include <Python.h>
+#include "gpio.h"
+
+// Used to recognize a reset request
+#define PIN_RESET 5
+
+// 8 bit bus for TI Data (TD)
+#define PIN_TD0 2
+#define PIN_TD1 3
+#define PIN_TD2 4
+#define PIN_TD3 17
+#define PIN_TD4 27
+#define PIN_TD5 22
+#define PIN_TD6 10
+#define PIN_TD7 9
+
+// 8 bit bus for TI Control (TC)
+#define PIN_TC0 14
+#define PIN_TC1 15
+#define PIN_TC2 18
+#define PIN_TC3 23
+#define PIN_TC4 24
+#define PIN_TC5 25
+#define PIN_TC6 8 
+#define PIN_TC7 7
+
+// Serial output for RD & RC
+#define PIN_CCLK 19
+#define PIN_DCLK 26
+#define PIN_SDATA 13
+#define PIN_LE 6 
+
+void setInput(int pin)
+{
+  INP_GPIO(pin);
+}
+
+void setOutput(int pin)
+{
+  INP_GPIO(pin);
+  OUT_GPIO(pin);
+}
+
+inline unsigned char getBit(int pin)
+{
+  return GET_GPIO(pin) ? 1 : 0;
+}
+
+static PyObject* 
+tipi_getTD(PyObject *self, PyObject *args)
+{
+  unsigned char td_value =
+    getBit(PIN_TD0) +
+    (getBit(PIN_TD1) << 1) +
+    (getBit(PIN_TD2) << 2) +
+    (getBit(PIN_TD3) << 3) +
+    (getBit(PIN_TD4) << 4) +
+    (getBit(PIN_TD5) << 5) +
+    (getBit(PIN_TD6) << 6) +
+    (getBit(PIN_TD7) << 7);
+
+  return Py_BuildValue("i", td_value);
+}
+
+static PyObject* 
+tipi_getTC(PyObject *self, PyObject *args)
+{
+  unsigned char tc_value =
+    getBit(PIN_TC0) +
+    (getBit(PIN_TC1) << 1) +
+    (getBit(PIN_TC2) << 2) +
+    (getBit(PIN_TC3) << 3) +
+    (getBit(PIN_TC4) << 4) +
+    (getBit(PIN_TC5) << 5) +
+    (getBit(PIN_TC6) << 6) +
+    (getBit(PIN_TC7) << 7);
+
+  return Py_BuildValue("i", tc_value);
+}
+
+inline void setBit(int set, int pin)
+{
+  *(gpio + (set ? 7 : 10)) = 1<<pin;
+}
+
+inline void writeByte(unsigned char value, int clock) 
+{
+  int i;
+  for (i=7; i>=0; i--) {
+    GPIO_CLR = 1<<clock;
+    setBit((value >> i) & 0x01, PIN_SDATA);
+    GPIO_SET = 1<<clock;
+  }
+  GPIO_CLR = 1<<clock;
+  GPIO_SET = 1<<PIN_LE;
+  GPIO_SET = 1<<clock;
+  GPIO_CLR = 1<<PIN_LE;
+  GPIO_CLR = 1<<clock;
+}
+
+static PyObject* 
+tipi_setRD(PyObject *self, PyObject *args)
+{
+  unsigned char rd_value;
+  PyArg_ParseTuple(args, "b", &rd_value);
+
+  writeByte(rd_value, PIN_DCLK);
+
+  Py_INCREF(Py_None);
+  return Py_None;
+}
+
+static PyObject* 
+tipi_setRC(PyObject *self, PyObject *args)
+{
+  unsigned char rc_value;
+  PyArg_ParseTuple(args, "b", &rc_value);
+
+  writeByte(rc_value, PIN_CCLK);
+
+  Py_INCREF(Py_None);
+  return Py_None;
+}
+
+static PyObject* 
+tipi_initGpio(PyObject *self, PyObject *args)
+{
+  setup_io();
+
+  setInput(PIN_TD0);
+  setInput(PIN_TD1);
+  setInput(PIN_TD2);
+  setInput(PIN_TD3);
+  setInput(PIN_TD4);
+  setInput(PIN_TD5);
+  setInput(PIN_TD6);
+  setInput(PIN_TD7);
+
+  setInput(PIN_TC0);
+  setInput(PIN_TC1);
+  setInput(PIN_TC2);
+  setInput(PIN_TC3);
+  setInput(PIN_TC4);
+  setInput(PIN_TC5);
+  setInput(PIN_TC6);
+  setInput(PIN_TC7);
+
+  setOutput(PIN_CCLK);
+  setOutput(PIN_DCLK);
+  setOutput(PIN_SDATA);
+  setOutput(PIN_LE);
+
+  Py_INCREF(Py_None);
+  return Py_None;
+}
+
+static PyMethodDef TipiMethods[] = {
+  {"getTD", tipi_getTD, METH_VARARGS, "get tipi input data"},
+  {"getTC", tipi_getTC, METH_VARARGS, "set tipi input signals"},
+  {"setRD", tipi_setRD, METH_VARARGS, "set tipi output data"},
+  {"setRC", tipi_setRC, METH_VARARGS, "set tipi output signals"},
+  {"initGpio", tipi_initGpio, METH_VARARGS, "set tipi gpio modes"},
+  {NULL, NULL, 0, NULL}
+};
+
+PyMODINIT_FUNC
+inittipiports(void)
+{
+  PyObject *m;
+  m = Py_InitModule("tipiports", TipiMethods);
+  if (m == NULL)
+    return;
+}
+

--- a/dsr/python/tipi/TipiPorts.py
+++ b/dsr/python/tipi/TipiPorts.py
@@ -1,123 +1,50 @@
 #!/usr/bin/env python
-import RPi.GPIO as GPIO 
+# import RPi.GPIO as GPIO 
 import sys
 import logging
+import tipiports
 
 logger = logging.getLogger("tipi")
 
 class TipiPorts(object):
 
     def __init__(self):
-        self.__RESET = 5
+        # self.__RESET = 5
 
-        self.__TD0 = 2
-        self.__TD1 = 3
-        self.__TD2 = 4
-        self.__TD3 = 17
-        self.__TD4 = 27
-        self.__TD5 = 22
-        self.__TD6 = 10
-        self.__TD7 = 9
+        # GPIO.setmode(GPIO.BCM) 
+        # GPIO.setwarnings(False)
 
-        self.__TD_BITS = [self.__TD0, self.__TD1, self.__TD2, self.__TD3, self.__TD4, self.__TD5, self.__TD6, self.__TD7]
-
-        self.__TC0 = 14
-        self.__TC1 = 15
-        self.__TC2 = 18
-        self.__TC3 = 23
-        self.__TC4 = 24
-        self.__TC5 = 25
-        self.__TC6 = 8
-        self.__TC7 = 7
-
-        self.__TC_BITS = [self.__TC0, self.__TC1, self.__TC2, self.__TC3, self.__TC4, self.__TC5, self.__TC6, self.__TC7]
-
-        self.__R_CCLK = 19
-        self.__R_DCLK = 26
-        self.__R_SDATA = 13
-        self.__R_LE = 6
- 
-        GPIO.setmode(GPIO.BCM) 
-        GPIO.setwarnings(False)
-
-        GPIO.setup(self.__TD_BITS, GPIO.IN)
-        GPIO.setup(self.__TC_BITS, GPIO.IN)
-
-        GPIO.setup(self.__R_CCLK, GPIO.OUT)
-        GPIO.setup(self.__R_DCLK, GPIO.OUT)
-        GPIO.setup(self.__R_SDATA, GPIO.OUT)
-        GPIO.setup(self.__R_LE, GPIO.OUT)
-
-	self.setRD(0)
-	self.setRC(0)
-        GPIO.output(self.__R_CCLK, 0)
-        GPIO.output(self.__R_DCLK, 0)
-        GPIO.output(self.__R_SDATA, 0)
-        GPIO.output(self.__R_LE, 0)
-
-        GPIO.setup(self.__RESET, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+        # GPIO.setup(self.__RESET, GPIO.IN, pull_up_down=GPIO.PUD_UP)
         # Do not proceed unless the reset signal has turned off
         # attempt to prevent restart storm in systemd
         
-        while GPIO.input(self.__RESET) != 1:
-            logger.info("waiting for reset to complete.")
-            pass
-        GPIO.add_event_detect(self.__RESET, GPIO.FALLING, callback=onReset, bouncetime=100)
-
+        # while GPIO.input(self.__RESET) != 1:
+        #     logger.info("waiting for reset to complete.")
+        #     pass
+        # GPIO.add_event_detect(self.__RESET, GPIO.FALLING, callback=onReset, bouncetime=100)
+        tipiports.initGpio()
         logger.info("GPIO initialized.")
 
 
-    #
-    # Read a byte of input from a set of 8 input pins
-    #
-    def __readBitsToByte(self, bits):
-        byte = 0
-
-        # GPIO.input returns 1 or 0. so just shift them into place.
-        byte += GPIO.input(bits[0]) # << 0
-        byte += GPIO.input(bits[1]) << 1
-        byte += GPIO.input(bits[2]) << 2
-        byte += GPIO.input(bits[3]) << 3
-        byte += GPIO.input(bits[4]) << 4
-        byte += GPIO.input(bits[5]) << 5
-        byte += GPIO.input(bits[6]) << 6
-        byte += GPIO.input(bits[7]) << 7
-
-        return byte
-
-    #
-    # Write a byte of to an 8 bit output register selected by clk
-    #
-    def __writeByteToRegister(self, byte, clk):
-        for i in reversed(range(0,8)):
-            GPIO.output(clk, 0)
-            GPIO.output(self.__R_SDATA, (byte >> i) & 0x01)
-            GPIO.output(clk, 1)
-        
-        GPIO.output(clk, 0)
-        GPIO.output(self.__R_LE, 1)
-        GPIO.output(clk, 1)
-        GPIO.output(self.__R_LE, 0)
-        GPIO.output(clk, 0)
-
     # Read TI_DATA
     def getTD(self):
-        return self.__readBitsToByte(self.__TD_BITS)
+        return tipiports.getTD()
 
     # Read TI_CONTROL
     def getTC(self):
-        return self.__readBitsToByte(self.__TC_BITS)
+        return tipiports.getTC()
 
     # Write RPI_DATA
     def setRD(self, value):
-        self.__writeByteToRegister(value, self.__R_DCLK)
+        tipiports.setRD(value)
 
     # Write RPI_CONTROL
     def setRC(self, value):
-        self.__writeByteToRegister(value, self.__R_CCLK)
+        tipiports.setRC(value)
 
 def onReset(channel):
-    print "responding to reset interrupt"
-    sys.exit(0)
+    # print "responding to reset interrupt"
+    # sys.exit(0)
+    pass
 
 

--- a/dsr/python/tipi/TipiPorts.py
+++ b/dsr/python/tipi/TipiPorts.py
@@ -9,7 +9,9 @@ logger = logging.getLogger("tipi")
 class TipiPorts(object):
 
     def __init__(self):
-        # self.__RESET = 5
+        self.__RESET = 5
+
+        tipiports.initGpio()
 
         # GPIO.setmode(GPIO.BCM) 
         # GPIO.setwarnings(False)
@@ -22,7 +24,6 @@ class TipiPorts(object):
         #     logger.info("waiting for reset to complete.")
         #     pass
         # GPIO.add_event_detect(self.__RESET, GPIO.FALLING, callback=onReset, bouncetime=100)
-        tipiports.initGpio()
         logger.info("GPIO initialized.")
 
 
@@ -43,8 +44,7 @@ class TipiPorts(object):
         tipiports.setRC(value)
 
 def onReset(channel):
-    # print "responding to reset interrupt"
-    # sys.exit(0)
-    pass
+    print "responding to reset interrupt"
+    sys.exit(0)
 
 

--- a/dsr/systemd/INSTALL.md
+++ b/dsr/systemd/INSTALL.md
@@ -6,10 +6,17 @@ signal. The systemd script will auto-restart it if it exists due to a reset, or 
 
 # systemd service installation
 
-cp tipi.service to /lib/systemd/system/
+```
+cp tipi.service /lib/systemd/system/
 
 systemctl enable tipi.service
 systemctl start tipi.service
 
-This wraps the fileserver.py script. 
+cp tipiwatchdog.service /lib/systemd/system/
+
+systemctl enable tipiwatchdog.service
+systemctl start tipiwatchdog.service
+```
+
+This wraps the fileserver.py script. And monitors the reset pin to trigger restarting the service.
 

--- a/dsr/systemd/tipiwatchdog.service
+++ b/dsr/systemd/tipiwatchdog.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=TI-99/4A DSR RESET Service
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/home/pi/dev/github/pi-messaging/dsr/python/TipiWatchDog.py
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
use native C python module 'tipiports' to twiddle the GPIO pins faster.

Required moving the reset handler to a separate process - TipiWatchDog.py 

RPi.GPIO is not compatible with 'tipiports' in the same process. 