### PR TITLE
Native files

### DIFF
--- a/dsr/python/TipiDisk.py
+++ b/dsr/python/TipiDisk.py
@@ -176,7 +176,7 @@ class TipiDisk(object):
         maxsize = recordNumber(pab)
         unix_name = tinames.devnameToLocal(devname)
         try:
-            if unix_name.lower().endswith(".bas") or unix_name.lower().endswith(".xb"):
+            if unix_name.lower().endswith((".bas", ".xb")):
                 prog_file = BasicFile.load(unix_name)
             else:
                 prog_file = ProgramImageFile.load(unix_name)

--- a/dsr/python/TipiDisk.py
+++ b/dsr/python/TipiDisk.py
@@ -5,11 +5,13 @@ import time
 import os
 import errno
 
-from ti_files import ti_files
+from ti_files.ti_files import ti_files
 from ti_files.ProgramImageFile import ProgramImageFile
 from ti_files.FixedRecordFile import FixedRecordFile
 from ti_files.VariableRecordFile import VariableRecordFile
 from ti_files.CatalogFile import CatalogFile
+from ti_files.NativeFile import NativeFile
+from ti_files.BasicFile import BasicFile
 from array import array
 from tipi.TipiMessage import TipiMessage
 from tifloat import tifloat
@@ -90,10 +92,13 @@ class TipiDisk(object):
         if os.path.exists(localPath):
             try:
                 open_file = None
-                if recordType(pab) == FIXED:
-                    open_file = FixedRecordFile.load(localPath, pab)
+                if ti_files.isTiFile(localPath):
+                    if recordType(pab) == FIXED:
+                        open_file = FixedRecordFile.load(localPath, pab)
+                    else:
+                        open_file = VariableRecordFile.load(localPath, pab)
                 else:
-                    open_file = VariableRecordFile.load(localPath, pab)
+                    open_file = NativeFile.load(localPath, pab)
 
                 fillInRecordLen = open_file.getRecordLength()
 
@@ -171,7 +176,11 @@ class TipiDisk(object):
         maxsize = recordNumber(pab)
         unix_name = tinames.devnameToLocal(devname)
         try:
-            prog_file = ProgramImageFile.load(unix_name)
+            if unix_name.lower().endswith(".bas") or unix_name.lower().endswith(".xb"):
+                prog_file = BasicFile.load(unix_name)
+            else:
+                prog_file = ProgramImageFile.load(unix_name)
+            
             filesize = prog_file.getImageSize()
             if filesize > maxsize:
                 logger.debug("TI buffer too small")

--- a/dsr/python/ti_files/BasicFile.py
+++ b/dsr/python/ti_files/BasicFile.py
@@ -1,0 +1,39 @@
+import logging
+from ti_files import ti_files
+from subprocess import call
+
+logger = logging.getLogger(__name__)
+
+class BasicFile(object):
+
+    def __init__(self, bytes):
+        self.body = bytes
+
+    @staticmethod
+    def load(unix_file_name):
+        fh = None
+        try:
+            tmpfp = "/tmp/xbas_tmp"
+            BasicFile.toBasic(unix_file_name, tmpfp)
+            fh = open(tmpfp, "rb")
+            bytes = bytearray(fh.read())
+            return BasicFile(bytes)
+        except Exception as e:
+            logger.error("Error reading file %s", unix_file_name)
+            raise
+        finally:
+            if fh != None:
+                fh.close()
+
+    def getImage(self):
+        return self.body
+
+    def getImageSize(self):
+        return len(self.body)
+
+    @staticmethod
+    def toBasic(fp, tmpfp):
+        cmdargs = ["/home/pi/dev/github/xdt99/xbas99.py", "-c", "-o", tmpfp, fp]
+        if call(cmdargs) != 0:
+            raise Exception("Invalid BASIC Source")
+ 

--- a/dsr/python/ti_files/CatalogFile.py
+++ b/dsr/python/ti_files/CatalogFile.py
@@ -58,24 +58,32 @@ class CatalogFile(object):
 
     def __createFileCatRecords(self):
         files = sorted(list(filter(lambda x: 
-            os.path.isdir(os.path.join(self.localpath, x)) or 
-            ti_files.isTiFile(str(os.path.join(self.localpath, x))), os.listdir(self.localpath))))
+            self.__include(os.path.join(self.localpath, x)), os.listdir(self.localpath))))
         return map(self.__createFileRecord, files)
 
+    def __include(self, fp):
+        logger.debug("__include %s", fp)
+        return os.path.isdir(fp) or ti_files.isTiFile(fp) or os.path.isfile(fp)
+
     def __createFileRecord(self, f):
+        logger.debug("createFileRecord %s", f)
         fh = None
         try:
-            if os.path.isdir(os.path.join(self.localpath, f)):
+            fp = os.path.join(self.localpath, f)
+            if os.path.isdir(fp):
                 return self.__encodeDirRecord(f, 6, 2, 0)
 
-            fh = open(os.path.join(self.localpath, f), 'rb')
+            if ti_files.isTiFile(fp):
+                fh = open(fp, 'rb')
 
-            header = bytearray(fh.read()[:128])
+                header = bytearray(fh.read()[:128])
 
-            ft = ti_files.dsrFileType(header)
-            sectors = ti_files.getSectors(header) + 1
-            recordlen = ti_files.recordLength(header)
-            return self.__encodeDirRecord(f, ft, sectors, recordlen)
+                ft = ti_files.dsrFileType(header)
+                sectors = ti_files.getSectors(header) + 1
+                recordlen = ti_files.recordLength(header)
+                return self.__encodeDirRecord(f, ft, sectors, recordlen)
+
+            return self.__encodeDirRecord(f, 1, 1, 128)
 
         except Exception as e:
             traceback.print_exc()
@@ -89,6 +97,7 @@ class CatalogFile(object):
         bytes = bytearray(38)
 
         shortname = tinames.asTiShortName(name)
+        logger.debug("cat record: %s, %d, %d, %d", shortname, ftype, sectors, recordLength)
 
         bytes[0] = len(shortname)
         i = 1

--- a/dsr/python/ti_files/CatalogFile.py
+++ b/dsr/python/ti_files/CatalogFile.py
@@ -83,7 +83,19 @@ class CatalogFile(object):
                 recordlen = ti_files.recordLength(header)
                 return self.__encodeDirRecord(f, ft, sectors, recordlen)
 
-            return self.__encodeDirRecord(f, 1, 1, 128)
+            # else it is a native file
+            if fp.endswith(".txt") or fp.endswith(".TXT"):
+                # dis/var
+                ft = 2
+                recCount = self.__line_count(fp)
+                recSize = 80
+            else:
+                # dis/fix
+                ft = 1
+                stats = os.stat(fp)
+                recCount = stats.st_size / 128 + 1
+                recSize = 128
+            return self.__encodeDirRecord(f, ft, recCount, recSize)
 
         except Exception as e:
             traceback.print_exc()
@@ -120,3 +132,10 @@ class CatalogFile(object):
             bytes[i] = 0
 
         return bytes
+
+    def __line_count(self, fp):
+        i = 0
+        with open(fp) as f:
+            for i, l in enumerate(f):
+                pass
+        return i + 1

--- a/dsr/python/ti_files/CatalogFile.py
+++ b/dsr/python/ti_files/CatalogFile.py
@@ -4,6 +4,7 @@ import sys
 import traceback
 import math
 import logging
+import NativeFile
 from ti_files import ti_files
 from tinames import tinames
 from tifloat import tifloat
@@ -84,7 +85,7 @@ class CatalogFile(object):
                 return self.__encodeDirRecord(f, ft, sectors, recordlen)
 
             # else it is a native file
-            if fp.endswith(".txt") or fp.endswith(".TXT"):
+            if fp.lower().endswith(NativeFile.dv80suffixes):
                 # dis/var
                 ft = 2
                 recCount = self.__line_count(fp)

--- a/dsr/python/ti_files/NativeFile.py
+++ b/dsr/python/ti_files/NativeFile.py
@@ -44,7 +44,7 @@ class NativeFile(object):
         return records
 
     @staticmethod
-    def loadBytes(fh):
+    def loadBytes(fp):
         records = []
         with open(fp) as f:
             bytes = bytearray(f.read())

--- a/dsr/python/ti_files/NativeFile.py
+++ b/dsr/python/ti_files/NativeFile.py
@@ -1,0 +1,79 @@
+import os
+import io
+import sys
+import traceback
+import math
+import magic
+import logging
+from ti_files import ti_files
+from Pab import *
+
+logger = logging.getLogger(__name__)
+
+dv80suffixes = (".txt", ".bas", ".xb", ".md")
+
+class NativeFile(object):
+
+    def __init__(self, records, recordLength):
+        self.records = records
+        self.currentRecord = 0
+        self.recordLength = recordLength
+
+    @staticmethod
+    def load(unix_file_name, pab):
+        try:
+            if unix_file_name.lower().endswith(dv80suffixes):
+                records = NativeFile.loadLines(unix_file_name)
+                recLen = 80
+            else:
+                records = NativeFile.loadBytes(unix_file_name)
+                recLen = 128
+            return NativeFile(records, recLen)
+        except Exception as e:
+            traceback.print_exc()
+            logger.error("not a valid Fixed Record TIFILE %s", unix_file_name)
+            return None
+
+    @staticmethod
+    def loadLines(fp):
+        i = 0
+        records = []
+        with open(fp) as f:
+            for i, l in enumerate(f):
+                records += [bytearray(l)]
+        return records
+
+    @staticmethod
+    def loadBytes(fh):
+        records = []
+        with open(fp) as f:
+            bytes = bytearray(f.read())
+            while len(bytes) >= 128:
+                records += [bytes[:128]]
+                bytes = bytes[128:]
+            if len(bytes) > 0:
+                padded = bytearray(128)
+                padded[0:] = bytes
+                records += [padded]
+        return records
+
+    def isLegal(self, pab):
+        return mode(pab) == INPUT
+
+    def readRecord(self, idx):
+        if idx != 0:
+            self.currentRecord = idx
+        record = self.getRecord(self.currentRecord)
+        self.currentRecord += 1
+        return record
+
+    def getRecord(self, idx):
+        if idx >= len(self.records):
+            return None
+        return self.records[idx]
+
+    def getRecordLength(self):
+        return self.recordLength
+
+
+

--- a/dsr/python/ti_files/NativeFile.py
+++ b/dsr/python/ti_files/NativeFile.py
@@ -40,7 +40,7 @@ class NativeFile(object):
         records = []
         with open(fp) as f:
             for i, l in enumerate(f):
-                records += [bytearray(l)]
+                records += [bytearray(l.rstrip())]
         return records
 
     @staticmethod

--- a/dsr/python/tinames/tinames.py
+++ b/dsr/python/tinames/tinames.py
@@ -28,6 +28,7 @@ def devnameToLocal(devname):
 
 
 def asTiShortName(name):
+    name = name.replace('.', '/')
     if len(name) <= 10:
         return name
     else:
@@ -60,4 +61,8 @@ def findpath(path, part):
                     os.listdir(path)))
             if candidates:
                 return candidates[0]
+        else:
+            lpart = part.replace("/", ".").replace("\\", ".")
+            if os.path.exists(str(os.path.join(path, lpart))):
+                return lpart
     return part


### PR DESCRIPTION
Foreign operating system files are now included in the CatalogFile of the TIPI filesystem. 
If the host os file name extension is one of .txt, .bas, .xb, or .md ( case insensitive ) then it will be presented to the TI as a Display Variable 80 file. 

Also, if the host os file name extension is one of .bas or .xb, then it can be loaded as a PROGRAM image file ( though it will not list as such ) into BASIC. The xdt99 suite tool xbas99.py is used to encode the ascii basic code into TI binary format. 

