### PR TITLE
support STATUS opcode for files that matter.

### DIFF
--- a/dsr/python/TipiDisk.py
+++ b/dsr/python/TipiDisk.py
@@ -248,6 +248,8 @@ class TipiDisk(object):
                         statbyte |= STPROGRAM
                     if ti_files.isInternal(header):
                         statbyte |= STINTERNAL
+                else:
+                    statbyte = NativeFile.status(localPath)
 
         self.tipi_io.send([SUCCESS])
         self.tipi_io.send([statbyte])

--- a/dsr/python/ti_files/FixedRecordFile.py
+++ b/dsr/python/ti_files/FixedRecordFile.py
@@ -57,6 +57,14 @@ class FixedRecordFile(object):
     def isLegal(self, pab):
         return mode(pab) == INPUT and recordType(pab) == FIXED
 
+    def getStatusByte(self):
+        statByte = 0
+        if ti_files.isInternal(self.header):
+            statByte |= STINTERNAL
+        if self.currentRecord >= len(self.records):
+            statByte |= STLEOF
+        return statByte
+
     def readRecord(self, idx):
         if idx != 0:
             self.currentRecord = idx

--- a/dsr/python/ti_files/NativeFile.py
+++ b/dsr/python/ti_files/NativeFile.py
@@ -62,6 +62,14 @@ class NativeFile(object):
                 records += [padded]
         return records
 
+    @staticmethod
+    def status(fp):
+        if fp.lower().endswith(dv80suffixes):
+            statByte = STVARIABLE
+        else:
+            statByte = 0
+        return statByte
+
     def isLegal(self, pab):
         return mode(pab) == INPUT
 

--- a/dsr/python/ti_files/NativeFile.py
+++ b/dsr/python/ti_files/NativeFile.py
@@ -14,10 +14,11 @@ dv80suffixes = (".txt", ".bas", ".xb", ".md")
 
 class NativeFile(object):
 
-    def __init__(self, records, recordLength):
+    def __init__(self, records, recordLength, statByte):
         self.records = records
         self.currentRecord = 0
         self.recordLength = recordLength
+        self.statByte = statByte
 
     @staticmethod
     def load(unix_file_name, pab):
@@ -25,10 +26,14 @@ class NativeFile(object):
             if unix_file_name.lower().endswith(dv80suffixes):
                 records = NativeFile.loadLines(unix_file_name)
                 recLen = 80
+                statByte = STVARIABLE
             else:
                 records = NativeFile.loadBytes(unix_file_name)
                 recLen = 128
-            return NativeFile(records, recLen)
+                statByte = 0
+                if dataType(pab):
+                    statByte |= STINTERNAL
+            return NativeFile(records, recLen, statByte)
         except Exception as e:
             traceback.print_exc()
             logger.error("not a valid Fixed Record TIFILE %s", unix_file_name)
@@ -59,6 +64,12 @@ class NativeFile(object):
 
     def isLegal(self, pab):
         return mode(pab) == INPUT
+
+    def getStatusByte(self):
+        statByte = self.statByte
+        if self.currentRecord >= len(self.records):
+            statByte |= STLEOF
+        return statByte
 
     def readRecord(self, idx):
         if idx != 0:

--- a/dsr/python/ti_files/VariableRecordFile.py
+++ b/dsr/python/ti_files/VariableRecordFile.py
@@ -45,6 +45,14 @@ class VariableRecordFile(object):
     def isLegal(self, pab):
         return mode(pab) == INPUT and recordType(pab) != FIXED
 
+    def getStatusByte(self):
+        statByte = STVARIABLE
+        if ti_files.isInternal(self.header):
+            statByte |= STINTERNAL
+        if self.currentRecord >= len(self.records):
+            statByte |= STLEOF
+        return statByte
+
     def readRecord(self, idx):
         if idx != 0:
             self.currentRecord = idx


### PR DESCRIPTION
Support status for open files with logical eof detection, as well as none open files to return file type. 

Previously implemented for special file 'StatusFile' ( the one that shows ip address info )
Now supported for real files, FixedRecordFile, VariableRecordFile, and NativeFile, and un-opened program images. 
