### PR TITLE
support write opcode for VARIABLE and FIXED record TIFILES

### DIFF
--- a/dsr/python/Pab.py
+++ b/dsr/python/Pab.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 import logging
 
 logger = logging.getLogger(__name__)

--- a/dsr/python/TipiDisk.py
+++ b/dsr/python/TipiDisk.py
@@ -201,6 +201,9 @@ class TipiDisk(object):
         logPab(pab)
         maxsize = recordNumber(pab)
         unix_name = tinames.devnameToLocal(devname)
+        if not os.path.exists(unix_name):
+            self.sendErrorCode(EFILERR)
+            return
         try:
             if (not ti_files.isTiFile(unix_name)) and unix_name.lower().endswith(basicSuffixes):
                 prog_file = BasicFile.load(unix_name)

--- a/dsr/python/TipiDisk.py
+++ b/dsr/python/TipiDisk.py
@@ -201,7 +201,7 @@ class TipiDisk(object):
         maxsize = recordNumber(pab)
         unix_name = tinames.devnameToLocal(devname)
         try:
-            if unix_name.lower().endswith((".bas", ".xb")):
+            if unix_name.lower().endswith((".b99", ".bas", ".xb")):
                 prog_file = BasicFile.load(unix_name)
             else:
                 prog_file = ProgramImageFile.load(unix_name)

--- a/dsr/python/TipiService.py
+++ b/dsr/python/TipiService.py
@@ -14,13 +14,8 @@ from TipiDisk import TipiDisk
 # Setup logging
 #
 logpath = "/home/tipi/log"
-try:
+if not os.path.isdir(logpath):
     os.makedirs(logpath)
-except OSError as exc:
-    if exc.errno == errno.EEXIST and os.path.isdir(logpath):
-        pass
-    else:
-        raise
 
 LOG_FILENAME = logpath + "/tipi.log"
 logging.getLogger('').setLevel(logging.INFO)

--- a/dsr/python/TipiService.py
+++ b/dsr/python/TipiService.py
@@ -38,37 +38,39 @@ oled = logging.getLogger('oled')
 ##
 # MAIN
 ##
+try:
+    oled.info("TIPI Init")
 
-oled.info("TIPI Init")
+    createResetListener()
 
-createResetListener()
+    tipi_io = TipiMessage()
+    specialFiles = SpecialFiles(tipi_io)
+    rawExtensions = RawExtensions(tipi_io)
+    tipiDisk = TipiDisk(tipi_io)
 
-tipi_io = TipiMessage()
-specialFiles = SpecialFiles(tipi_io)
-rawExtensions = RawExtensions(tipi_io)
-tipiDisk = TipiDisk(tipi_io)
+    oled.info("TIPI Ready")
 
-oled.info("TIPI Ready")
+    while True:
+        logger.info("waiting for PAB request...")
 
-while True:
-    logger.info("waiting for PAB request...")
+        pab = tipi_io.receive()
+        if rawExtensions.handle(pab):
+            continue
 
-    pab = tipi_io.receive()
-    if rawExtensions.handle(pab):
-        continue
+        logger.debug("PAB received.")
 
-    logger.debug("PAB received.")
+        logger.debug("waiting for devicename...")
+        devicename = tipi_io.receive()
 
-    logger.debug("waiting for devicename...")
-    devicename = tipi_io.receive()
+        # Special file name requests to force different errors
+        filename = str(devicename)
 
-    # Special file name requests to force different errors
-    filename = str(devicename)
+        if specialFiles.handle(pab, filename):
+            continue
 
-    if specialFiles.handle(pab, filename):
-        continue
+        # nothing special, so fall back to disk access
+        tipiDisk.handle(pab, filename)
 
-    # nothing special, so fall back to disk access
-    tipiDisk.handle(pab, filename)
-
-    logger.info("Request completed.")
+        logger.info("Request completed.")
+except Exception as e:
+    logger.error("Unhandled exception in main", exc_info=True)

--- a/dsr/python/ti_files/BasicFile.py
+++ b/dsr/python/ti_files/BasicFile.py
@@ -25,6 +25,26 @@ class BasicFile(object):
             if fh != None:
                 fh.close()
 
+    @staticmethod
+    def create(fdata):
+        return BasicFile(fdata)
+
+    def save(self, unix_file_name):
+        fh = None
+        try:
+            tmpfp = "/tmp/xbas_tmp"
+            fh = open(tmpfp, "wb")
+            fh.write(self.body)
+            fh.close()
+            fh = None
+            BasicFile.toText(tmpfp, unix_file_name)
+        except Exception as e:
+            logger.exception("failed to save BasicFile")
+            raise
+        finally:
+            if fh != None:
+                fh.close()
+
     def getImage(self):
         return self.body
 
@@ -36,4 +56,10 @@ class BasicFile(object):
         cmdargs = ["/home/tipi/xdt99/xbas99.py", "-c", "-o", tmpfp, fp]
         if call(cmdargs) != 0:
             raise Exception("Invalid BASIC Source")
+
+    @staticmethod
+    def toText(tmpfp, fp):
+        cmdargs = ["/home/tipi/xdt99/xbas99.py", "-d", "-o", fp, tmpfp]
+        if call(cmdargs) != 0:
+            raise Exception("Invalid BASIC Program")
  

--- a/dsr/python/ti_files/NativeFile.py
+++ b/dsr/python/ti_files/NativeFile.py
@@ -22,22 +22,29 @@ class NativeFile(object):
 
     @staticmethod
     def load(unix_file_name, pab):
+        if mode(pab) != INPUT:
+            raise Exception("Native files are read only")
+
         try:
             if unix_file_name.lower().endswith(dv80suffixes):
+                if recordLength(pab) != 80 and recordLength(pab) != 0:
+                    raise Exception("Incompatible recordlength")
                 records = NativeFile.loadLines(unix_file_name)
                 recLen = 80
                 statByte = STVARIABLE
             else:
+                if recordLength(pab) != 128 and recordLength(pab) != 0:
+                    raise Exception("Incompatible recordlength")
                 records = NativeFile.loadBytes(unix_file_name)
                 recLen = 128
                 statByte = 0
                 if dataType(pab):
                     statByte |= STINTERNAL
             return NativeFile(records, recLen, statByte)
+
         except Exception as e:
-            traceback.print_exc()
-            logger.error("not a valid Fixed Record TIFILE %s", unix_file_name)
-            return None
+            logger.exception("not a valid NativeFile %s", unix_file_name)
+            raise
 
     @staticmethod
     def loadLines(fp):

--- a/dsr/python/ti_files/NativeFile.py
+++ b/dsr/python/ti_files/NativeFile.py
@@ -10,7 +10,7 @@ from Pab import *
 
 logger = logging.getLogger(__name__)
 
-dv80suffixes = (".txt", ".bas", ".xb", ".md")
+dv80suffixes = (".txt", ".a99", ".b99", ".bas", ".xb")
 
 class NativeFile(object):
 

--- a/dsr/python/ti_files/VariableRecordFile.py
+++ b/dsr/python/ti_files/VariableRecordFile.py
@@ -1,10 +1,10 @@
 import os
 import io
 import sys
-import traceback
 import math
 import logging
 from ti_files import ti_files
+from tinames import tinames
 from Pab import *
 
 logger = logging.getLogger(__name__)
@@ -12,10 +12,26 @@ logger = logging.getLogger(__name__)
 class VariableRecordFile(object):
 
     def __init__(self, bytes):
+        self.dirty = False
         self.header = bytes[:128]
         self.recordLength = ti_files.recordLength(self.header)
         self.records = self.__loadRecords(bytes[128:])
         self.currentRecord = 0
+
+    @staticmethod
+    def create(devname, localPath, pab):
+        nameParts = str(devname).split('.')
+        tiname = nameParts[len(nameParts) - 1]
+        recLen = recordLength(pab)
+        if recLen == 0:
+            recLen = 80
+        flags = ti_files.VARIABLE
+        if dataType(pab) == INTERNAL:
+            flags |= ti_files.INTERNAL
+        header = ti_files.createHeader(flags, tiname, bytearray(0))
+        ti_files.setRecordLength(header, recLen)
+        ti_files.setRecordsPerSector(header, int(256/recLen))
+        return VariableRecordFile(header)
 
     @staticmethod
     def load(unix_file_name, pab):
@@ -35,8 +51,7 @@ class VariableRecordFile(object):
                 raise Exception("file is FIXED, must be VARIABLE")
             return VariableRecordFile(fdata)
         except Exception as e:
-            traceback.print_exc()
-            logger.error("not a valid Variable Record TIFILE %s", unix_file_name)
+            logger.exception("not a valid Variable Record TIFILE %s", unix_file_name)
             return None
         finally:
             if fh != None:
@@ -52,6 +67,16 @@ class VariableRecordFile(object):
         if self.currentRecord >= len(self.records):
             statByte |= STLEOF
         return statByte
+
+    def writeRecord(self, bytes, pab):
+        self.dirty = True
+        recNo = recordNumber(pab)
+        if recNo != 0:
+            self.currentRecord = recNo
+        if self.currentRecord >= len(self.records):
+            self.records += [bytearray(0)] * (1 + self.currentRecord - len(self.records))
+        self.records[self.currentRecord] = bytearray(bytes)
+        self.currentRecord += 1
 
     def readRecord(self, idx):
         if idx != 0:
@@ -98,3 +123,62 @@ class VariableRecordFile(object):
             logger.debug("record: %s", str(record))
             records += [record]
         return records
+
+    def close(self, localPath):
+        if self.dirty:
+            try:
+                logger.debug("Dirty file, writing to disk %s", localPath)
+                logger.debug("records: %d", len(self.records))
+                shortName = tinames.asTiShortName(localPath)
+                logger.debug("writing TIFILE: %s", shortName)
+                bytes = self.__packRecords()
+                logger.debug("tifile length %d", len(bytes))
+                fh = open(localPath, "wb")
+                fh.write(bytes)
+                fh.close()
+                self.dirty = False
+            except Exception as e:
+                logger.exception("Failed to save file %s", localPath)
+
+    def __packRecords(self):
+        sectors = []
+        sector = bytearray(256)
+        recNo = 0
+        offset = 0
+        while recNo < len(self.records):
+            rec = self.records[recNo]
+            recLen = len(rec)
+            if (255 - offset) <= (recLen + 1):
+                sector[offset] = 0xff
+                sectors += [sector]
+                offset = 0
+                sector = bytearray(256)
+            sector[offset] = recLen
+            offset += 1
+            if recLen > 0:
+                sector[offset:offset + recLen] = rec
+                offset += recLen
+            recNo += 1
+            
+        if offset != 0:
+            sector[offset] = 0xff
+            offset += 1
+            sectors += [sector]
+        sectorCount = len(sectors)
+
+        # create a header, and also pack into single bytearray
+        header = bytearray(self.header)
+        ti_files.setSectors(header, sectorCount)
+        ti_files.setEofOffset(header, offset)
+        # seems wrong, but isn't
+        ti_files.setRecordCount(header, sectorCount)
+
+        bytes = bytearray(128 + (sectorCount * 256))
+        bytes[:128] = header
+        idx = 128
+        sec = 0
+        while sec < sectorCount:
+            bytes[idx:] = sectors[sec]
+            sec += 1
+            idx += 256
+        return bytes

--- a/dsr/python/ti_files/ti_files.py
+++ b/dsr/python/ti_files/ti_files.py
@@ -53,8 +53,20 @@ class ti_files(object):
         return bytes[0] == 0x07 and str(bytes[1:8]) == "TIFILES"
 
     @staticmethod
+    def setTiFile(bytes):
+        bytes[0] = 0x07
+        bytes[1:8] = "TIFILES"
+
+    @staticmethod
     def getSectors(bytes):
         return bytes[9] + (bytes[8] << 8)
+
+    @staticmethod
+    def setSectors(bytes, sectors):
+        lsb = 0xff & sectors
+        msb = sectors >> 8
+        bytes[8] = msb
+        bytes[9] = lsb
 
     @staticmethod
     def flags(bytes):
@@ -65,20 +77,43 @@ class ti_files(object):
         return bytes[11]
 
     @staticmethod
+    def setRecordsPerSector(bytes, rps):
+        bytes[11] = rps
+
+    @staticmethod
     def eofOffset(bytes):
         return bytes[12]
+
+    @staticmethod
+    def setEofOffset(bytes, offset):
+        bytes[12] = offset
 
     @staticmethod
     def recordLength(bytes):
         return bytes[13]
 
     @staticmethod
+    def setRecordLength(bytes, recLen):
+        bytes[13] = recLen
+
+    @staticmethod
     def recordCount(bytes):
         return bytes[14] + (bytes[15] << 8)
 
     @staticmethod
+    def setRecordCount(bytes, count):
+        lsb = count & 0xff
+        msb = count >> 8
+        bytes[14] = lsb
+        bytes[15] = msb
+
+    @staticmethod
     def tiName(bytes):
         return str(bytes[0x10:0x1A])
+
+    @staticmethod
+    def setName(bytes, shortName):
+        bytes[0x10:0x1A] = shortName
 
     @staticmethod
     def byteLength(bytes):

--- a/dsr/python/ti_files/ti_files.py
+++ b/dsr/python/ti_files/ti_files.py
@@ -19,7 +19,7 @@ class ti_files(object):
     def isTiFile(filename):
         fh = None
         try:
-            if os.stat(filename).st_size >= 128:
+            if os.path.exists(filename) and os.stat(filename).st_size >= 128:
                 fh = open(filename, 'rb')
                 header = bytearray(fh.read()[:9])
                 isGood = ti_files.isValid(header)

--- a/dsr/python/tinames/tinames.py
+++ b/dsr/python/tinames/tinames.py
@@ -1,10 +1,12 @@
 import sys
 import os
 import re
+import logging
 from crccheck.crc import Crc15
 
 # Transform a name supplied by the 4A into our storage path
 
+logger = logging.getLogger(__name__)
 
 def devnameToLocal(devname):
     parts = str(devname).split('.')
@@ -24,7 +26,9 @@ def devnameToLocal(devname):
 
     for part in parts[1:]:
         if part != "":
+            logger.debug("matching path part: %s", part)
             path += "/" + findpath(path, part)
+            logger.debug("building path: %s", path)
 
     path = str(path)
 
@@ -52,6 +56,7 @@ def baseN(num, b, numerals="0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"):
 
 
 def findpath(path, part):
+    part = part.replace("/", ".").replace("\\", ".")
     # if the file actually exists (or dir) then use literal name
     if os.path.exists(str(os.path.join(path, part))):
         return part
@@ -67,8 +72,5 @@ def findpath(path, part):
                     os.listdir(path)))
             if candidates:
                 return candidates[0]
-        else:
-            lpart = part.replace("/", ".").replace("\\", ".")
-            if os.path.exists(str(os.path.join(path, lpart))):
-                return lpart
+
     return part

--- a/dsr/python/tinames/tinames.py
+++ b/dsr/python/tinames/tinames.py
@@ -31,10 +31,10 @@ def devnameToLocal(devname):
     return path
 
 # Transform long host filename to 10 character TI filename
-
-
 def asTiShortName(name):
-    name = name.replace('.', '/')
+    parts = name.split('/')
+    lastpart = parts[len(parts)-1]
+    name = lastpart.replace('.', '/')
     if len(name) <= 10:
         return name
     else:


### PR DESCRIPTION
Fixed sector encoding of fixed record files, and enabled writing to record based files. supports append mode, and other relative record modes. 

Added restriction that VARIABLE record length files are not supposed to support RELATIVE access. 

Also includes fixes to saving BASIC in native file formats if name ends in native suffix .bas .xb or .b99
