### PR TITLE
fix reading protected bit and sending to catalog

### DIFF
--- a/services/ti_files/CatalogFile.py
+++ b/services/ti_files/CatalogFile.py
@@ -82,7 +82,7 @@ class CatalogFile(object):
 
                 header = bytearray(fh.read()[:128])
 
-                ft = ti_files.dsrFileType(header)
+                ft = ti_files.catFileType(header)
                 sectors = ti_files.getSectors(header) + 1
                 recordlen = ti_files.recordLength(header)
                 return self.__encodeDirRecord(f, ft, sectors, recordlen)

--- a/services/ti_files/ti_files.py
+++ b/services/ti_files/ti_files.py
@@ -12,7 +12,7 @@ class ti_files(object):
 
     PROGRAM = 0x01
     INTERNAL = 0x02
-    PROTECTED = 0x04
+    PROTECTED = 0x08
     VARIABLE = 0x80
 
     @staticmethod
@@ -123,20 +123,23 @@ class ti_files(object):
         return ((ti_files.getSectors(bytes) - 1) * 256) + eofsize
 
     @staticmethod
-    def dsrFileType(bytes):
+    def catFileType(bytes):
+        protected = 1
+	if ti_files.isProtected(bytes):
+            protected = -1
         if ti_files.isProgram(bytes):
-            return 5
+            return 5 * protected
 
         if ti_files.isInternal(bytes):
             if ti_files.isVariable(bytes):
-                return 4
+                return 4 * protected
             else:
-                return 3
+                return 3 * protected
         else:
             if ti_files.isVariable(bytes):
-                return 2
+                return 2 * protected
             else:
-                return 1
+                return 1 * protected
 
         return 0
 


### PR DESCRIPTION
I was reading the wrong bit as protected, and for catalogs you must negate the filetype if it is protected... odd, but fixed. 

fixes #64 