### PR TITLE
Faster pi zero

### DIFF
--- a/services/libtipi/rebuild.sh
+++ b/services/libtipi/rebuild.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cd /home/tipi/tipi/services
+. ./ENV/bin/activate
+cd /home/tipi/tipi/services/libtipi
+python setup.py install
+

--- a/services/libtipi/tipiports.c
+++ b/services/libtipi/tipiports.c
@@ -1,6 +1,7 @@
 
 #include <Python.h>
 #include <wiringPi.h>
+#include <stdlib.h>
 
 // Serial output for RD & RC (BCM pin numbers)
 #define PIN_R_RT 13
@@ -18,11 +19,13 @@
 // volatile to force slow memory access.
 volatile long delmem = 55; 
 
+int delayloop = 50;
+
 inline void signalDelay(void)
 {
   // delayMicroseconds(1L);
   int i = 0;
-  for(i = 0; i < 50; i++) {
+  for(i = 0; i < delayloop; i++) {
     delmem *= i;
   }
 }
@@ -129,6 +132,14 @@ tipi_setRC(PyObject *self, PyObject *args)
 static PyObject* 
 tipi_initGpio(PyObject *self, PyObject *args)
 {
+  // get signalling delay from env
+  const char* tipiSigEnv = getenv("TIPI_SIG_DELAY");
+  if (tipiSigEnv==NULL) {
+    delayloop = 0;
+  } else {
+    delayloop = atoi(tipiSigEnv);
+  }
+
   wiringPiSetupGpio();
 
   pinMode(PIN_R_RT, OUTPUT);

--- a/services/tipi.sh
+++ b/services/tipi.sh
@@ -4,5 +4,14 @@ cd /home/tipi/tipi/services
 
 source ENV/bin/activate
 
+cat /sys/firmware/devicetree/base/model | grep "Pi Zero W" >/dev/null 2>&1
+if [ $? == 0 ]; then
+  # signalling delay for PI Zero W
+  export TIPI_SIG_DELAY=0
+else
+  # signalling delay for PI 3
+  export TIPI_SIG_DELAY=50
+fi
+
 python ./TipiService.py
 

--- a/setup/post-upgrade.sh
+++ b/setup/post-upgrade.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+su tipi -c "/home/tipi/tipi/services/libtipi/rebuild.sh"
+
 cd /home/tipi/tipi/setup/
 
 systemctl stop tipiwatchdog.service


### PR DESCRIPTION
PI zero w's are significantly slower than PI 3. So signalling delay did not need to be so long. 
Actually works well at 0. 

PI 3, last I tested, failed without some delay... but that could have been a cabling issue... this leaves the delay the same for PI 3.  But this can easily be tuned in tipi.sh

PI Zero W now transfers at about 7k/sec instead of the typical 4k/sec prior to this change.