### PR TITLE
URI? mappings to enable shorter path names

### DIFF
--- a/hardware/dsr/header.a99
+++ b/hardware/dsr/header.a99
@@ -71,10 +71,31 @@ tipid
 	EVEN
 
 tipip
-	DATA	>0000		; terminate dsr list.
+	DATA	tipiu1		; terminate dsr list.
 	DATA	tipidsr		; tipi dsr routine pointer
 	BYTE	2		; TIPI Drive name length
 	TEXT	"PI"		; name of tipi drive
+	EVEN
+
+tipiu1
+	DATA	tipiu2		; terminate dsr list.
+	DATA	tipidsr		; tipi dsr routine pointer
+	BYTE	4		; TIPI Drive name length
+	TEXT	"URI1"		; name of tipi drive
+	EVEN
+
+tipiu2
+	DATA	tipiu3		; terminate dsr list.
+	DATA	tipidsr		; tipi dsr routine pointer
+	BYTE	4		; TIPI Drive name length
+	TEXT	"URI2"		; name of tipi drive
+	EVEN
+
+tipiu3
+	DATA	>0000		; terminate dsr list.
+	DATA	tipidsr		; tipi dsr routine pointer
+	BYTE	4		; TIPI Drive name length
+	TEXT	"URI3"		; name of tipi drive
 	EVEN
 
 ; Basic routine list ( name must be no more than 7 characters )

--- a/services/SpecialFiles.py
+++ b/services/SpecialFiles.py
@@ -8,8 +8,11 @@ from ConfigFile import ConfigFile
 from UpgradeFile import UpgradeFile
 from ShutdownFile import ShutdownFile
 from RebootFile import RebootFile
+from TipiConfig import TipiConfig
 
 logger = logging.getLogger(__name__)
+
+tipi_config = TipiConfig.instance()
 
 class SpecialFiles(object):
 
@@ -27,6 +30,12 @@ class SpecialFiles(object):
         }
 
     def handle(self, pab, devname):
+        if devname.startswith("URI[1-3]".):
+            uriShortcut = str(devname[:4])
+            link = tipi_config.get(uriShortCut)
+            if link != "":
+                devname = "PI." + link + "/" + devname[5:]
+                logger.debug("using %s to map to %s", uriShortcut, devname)
         if devname.startswith("PI."):
             fname = str(devname[3:])
             logger.debug("Looking for special file handler: %s", fname)

--- a/services/SpecialFiles.py
+++ b/services/SpecialFiles.py
@@ -30,9 +30,10 @@ class SpecialFiles(object):
         }
 
     def handle(self, pab, devname):
-        if devname.startswith("URI[1-3]".):
+        logger.debug("Matching special file handler for: %s", devname)
+        if devname.startswith(("URI1.","URI2.","URI3.")):
             uriShortcut = str(devname[:4])
-            link = tipi_config.get(uriShortCut)
+            link = tipi_config.get(uriShortcut)
             if link != "":
                 devname = "PI." + link + "/" + devname[5:]
                 logger.debug("using %s to map to %s", uriShortcut, devname)

--- a/services/TipiConfig.py
+++ b/services/TipiConfig.py
@@ -16,6 +16,9 @@ CONFIG_DEFAULTS = {
     "DSK1_DIR": "",
     "DSK2_DIR": "",
     "DSK3_DIR": "",
+    "URI1": "",
+    "URI2": "",
+    "URI3": "",
     "TIPI_NAME": "TIPI",
     "WIFI_SSID": "",
     "WIFI_PSK": ""


### PR DESCRIPTION
User can set PI.CONFIG items URI1, URI2, and URI3, to an HTTP url that will be used as a prefix when
opening files using drive paths of URI1.  or URI2.  

For instance, set URI1=HTTP://www.cwfk.net/4afiles
and in EA Option 5, load :   URI1.AMBULANCE

It will resolve to HTTP://www.cwfk.net/4afiles/AMBULANCE

It is important that the HTTP is in upper case.