### PR TITLE
Fix auto increments

### DIFF
--- a/hardware/dsr/devices.a99
+++ b/hardware/dsr/devices.a99
@@ -147,39 +147,29 @@ reterr
 	RT
 
 ; RPi thinks it can handle this request :) Good news!
+
+; routines have gotten too far away for JMP instructions, so I need to 
+; compute a branch target
+
+handlers			; 2x opcode + handlers is address to branch to.
+	DATA	hopen
+	DATA	hclose
+	DATA	hread
+	DATA	hwrite
+	DATA	hrestore
+	DATA	hload
+	DATA	hsave
+	DATA	hdelete
+	DATA	retdone		; scratch opcode not implemented.
+	DATA	hstatus
+
 hresponse
 	CLR	R1		; switch on opcode in R1
-	MOVB	@OPCODE(R10),R1
-
-	CI	R1,OPOPEN
-	JEQ	hopen
-
-	CI	R1,OPCLOSE
-	JEQ	hclose
-
-	CI	R1,OPREAD
-	JEQ	hread
-
-	CI	R1,OPWRITE
-	JEQ	hwrite
-
-	CI	R1,OPLOAD
-	JEQ	hload
-
-	CI	R1,OPSAVE
-	JEQ	hsave
-
-	CI	R1,OPSTAT
-	JEQ	hstatus
-
-	CI	R1,OPREST
-	JEQ	hrestore
-
-	CI	R1,OPDEL
-	JEQ	hdelete
-
-	LI	R1,EDEVERR	;   default: return device error
-	JMP	reterr
+	MOVB	@OPCODE(R10),@R1LB(R10)
+	SLA	R1,1		; multiply by 2
+	AI	R1,handlers	; R1 now has address of handler reference
+	MOV	*R1,R1
+	B	*R1		; goto handler for opcode...
 
 ; Handle OPCODE 0 - OPEN
 hopen
@@ -208,12 +198,20 @@ hread
 	AI	R3,CHRCNT-OPCODE
 	.setvdpwa R3
 	MOVB	R0,@VDPWD
+
+updaterec	; if RELATIVE mode, then we have to increment the record number
+	MOV	@OPCODE(R10),R1	; we'll only look at the 2nd byte @FLGSTS
+	ANDI	R1,1		; file-type 1 is RELATIVE
+	JEQ	retdone		; if SEQUENTIAL, then we are done.
+
 	MOV 	@RECNUM(R10),R1	; increment the VDP PAB record number
 	INC	R1
 	MOV	@VPAB,R3
 	AI	R3,RECNUM-OPCODE
 	.setvdpwa R3
 	MOVB	R1,@VDPWD
+	MOVB	@R1LB(R10),@VDPWD
+
 	JMP	retdone
 
 ; Handle OPCODE 3 - WRITE
@@ -230,12 +228,14 @@ hwrite
 	CLR	R9		; clear value in R9 so MSB is 0.
 	BL	@recvmsg	; receive single byte response from TIPI into R9
 	CI	R9,SUCCESS
-	JEQ	retdone
+	JEQ	updaterec
 	MOV	R9,R1
 	B	@reterr
 
 ; Handle OPCODE 4 - Restore
 hrestore
+	; If a RELATIVE access mode is used, then the request has updated the PAB
+	; If a SEQUENTIAL access mode is used, the PI just needs to reset the incrementor
 	JMP	retdone		; No further work on TI side.
 
 ; Handle response for OPCODE 5 - LOAD

--- a/services/TipiDisk.py
+++ b/services/TipiDisk.py
@@ -233,6 +233,30 @@ class TipiDisk(object):
     def handleRestore(self, pab, devname):
         logger.info("Opcode 4 Restore - %s", devname)
         logPab(pab)
+        localPath = tinames.devnameToLocal(devname)
+        if localPath is None:
+            logger.info("Passing to other controllers")
+            self.sendErrorcode(EDVNAME)
+            return
+
+        if localPath not in self.openFiles:
+            # pass as well
+            self.sendErrorCode(EDVNAME)
+            return
+
+        try:
+            open_file = self.openFiles[localPath]
+            if open_file == None:
+                self.sendErrorCode(EFILERR)
+                return
+
+            open_file.restore(pab)
+            self.sendSuccess()
+
+        except Exception as e:
+            traceback.print_exc()
+            self.sendErrorCode(EFILERR)
+
         self.sendErrorCode(EDEVERR)
 
     def handleLoad(self, pab, devname):

--- a/services/ti_files/NativeFile.py
+++ b/services/ti_files/NativeFile.py
@@ -14,11 +14,12 @@ dv80suffixes = (".txt", ".a99", ".b99", ".bas", ".xb")
 
 class NativeFile(object):
 
-    def __init__(self, records, recordLength, statByte):
+    def __init__(self, records, recordLength, statByte,pab):
         self.records = records
         self.currentRecord = 0
         self.recordLength = recordLength
         self.statByte = statByte
+        self.filetype = fileType(pab)
 
     @staticmethod
     def load(unix_file_name, pab):
@@ -40,7 +41,7 @@ class NativeFile(object):
                 statByte = 0
                 if dataType(pab):
                     statByte |= STINTERNAL
-            return NativeFile(records, recLen, statByte)
+            return NativeFile(records, recLen, statByte,pab)
 
         except Exception as e:
             logger.exception("not a valid NativeFile %s", unix_file_name)
@@ -86,8 +87,14 @@ class NativeFile(object):
             statByte |= STLEOF
         return statByte
 
+    def restore(self, pab):
+        if filetype == RELATIVE:
+            self.currentRecord = recordNumber(pab)
+        else:
+            self.currentRecord = 0
+
     def readRecord(self, idx):
-        if idx != 0:
+        if filetype == RELATIVE:
             self.currentRecord = idx
         record = self.getRecord(self.currentRecord)
         self.currentRecord += 1

--- a/services/ti_files/VariableRecordFile.py
+++ b/services/ti_files/VariableRecordFile.py
@@ -74,19 +74,17 @@ class VariableRecordFile(object):
             statByte |= STLEOF
         return statByte
 
+    def restore(self, pab):
+        self.currentRecord = 0
+
     def writeRecord(self, rdata, pab):
         self.dirty = True
-        recNo = recordNumber(pab)
-        if recNo != 0:
-            self.currentRecord = recNo
         if self.currentRecord >= len(self.records):
             self.records += [bytearray(0)] * (1 + self.currentRecord - len(self.records))
         self.records[self.currentRecord] = bytearray(rdata)
         self.currentRecord += 1
 
     def readRecord(self, idx):
-        if idx != 0:
-            self.currentRecord = idx
         record = self.getRecord(self.currentRecord)
         self.currentRecord += 1
         return record


### PR DESCRIPTION
Apparently I hadn't encountered files that bounce around between records using RELATIVE access mode... or the 'filetype' as TI calls it. 

Anyway... The Infocom game Deadline loads now.  The XB loader on the whtech deadline.arc seems to be bad.. it just crashes to console... or it needs sector io... But it just loads an EA5 program and large data files... so any EA5 loader seems to work... including CALL TIPI("DSK1.DEADLINE")

Maybe I should implement the >10 sector read write routine and just log and throw an error so I can tell if that is being looked for... 

