### PR TITLE
Changes to support the concept of GLOBAL TipiNetvars + Context.

### DIFF
--- a/services/TipiVariable.py
+++ b/services/TipiVariable.py
@@ -3,7 +3,6 @@
 # ElectricLab
 # Class to support "Network Variables"
 #
-#
 
 import struct
 import fcntl
@@ -18,7 +17,6 @@ logger = logging.getLogger(__name__)
 
 runtime_dir = '/home/tipi/.tipivars/'
 
-
 class TipiVariable(object):
 
     def __init__(self, tipi_io):
@@ -29,25 +27,28 @@ class TipiVariable(object):
         ti_message = message.split( chr(0x1e) )
         
         caller_guid     = ti_message[0] if len(ti_message) >= 1 else ''    # Program's GUID
-        action          = ti_message[1] if len(ti_message) >= 2 else ''    # 'R', 'RS', 'W', 'U', 'T'   read, read-simple, write, transmit via UDP, transmit via TCP
-        queue           = ti_message[2] if len(ti_message) >= 3 else ''    # Allow values to queue for these variables. (only locally for now)
-        results_var     = ti_message[3] if len(ti_message) >= 4 else ''    # results_var (optional)
-        var_key1        = ti_message[4] if len(ti_message) >= 5 else ''    # var key
-        var_val1        = ti_message[5] if len(ti_message) >= 6 else ''    # var val
-        var_key2        = ti_message[6] if len(ti_message) >= 7 else ''    # var key
-        var_val2        = ti_message[7] if len(ti_message) >= 8 else ''    # var val
-        var_key3        = ti_message[8] if len(ti_message) >= 9 else ''    # var key
-        var_val3        = ti_message[9] if len(ti_message) >= 10 else ''   # var val
-        var_key4        = ti_message[10] if len(ti_message) >= 11 else ''  # var key
-        var_val4        = ti_message[11] if len(ti_message) >= 12 else ''  # var val
+        context         = ti_message[1] if len(ti_message) >= 2 else ''    # optional context, used when storing on myti99.com. Does Not Apply locally.
+        action          = ti_message[2] if len(ti_message) >= 3 else ''    # 'R', 'RS', 'W', 'U', 'T'   read, read-simple, write, transmit via UDP, transmit via TCP
+        queue           = ti_message[3] if len(ti_message) >= 4 else ''    # Allow values to queue for these variables. (only locally for now)
+        results_var     = ti_message[4] if len(ti_message) >= 5 else ''    # results_var (optional)
+        var_key1        = ti_message[5] if len(ti_message) >= 6 else ''    # var key
+        var_val1        = ti_message[6] if len(ti_message) >= 7 else ''    # var val
+        var_key2        = ti_message[7] if len(ti_message) >= 8 else ''    # var key
+        var_val2        = ti_message[8] if len(ti_message) >= 9 else ''    # var val
+        var_key3        = ti_message[9] if len(ti_message) >= 10 else ''    # var key
+        var_val3        = ti_message[10] if len(ti_message) >= 11 else ''  # var val
+        var_key4        = ti_message[11] if len(ti_message) >= 12 else ''  # var key
+        var_val4        = ti_message[12] if len(ti_message) >= 13 else ''  # var val
 
         response = str(results_var) if len(results_var) else ''
 
         # Load our existing variables into a dict:
         self.ti_vars = {}
+        self.ti_global = {}
         
         guid_file = runtime_dir + caller_guid
-        
+        global_file = runtime_dir + 'GLOBAL'
+
         if os.path.isfile(str(guid_file)):
             with open(str(guid_file), "r") as f:
                 for line in f:
@@ -58,6 +59,19 @@ class TipiVariable(object):
                         self.ti_vars[data[0]] = data[1]
 
             f.close
+            
+        if os.path.isfile(str(global_file)):
+            with open(str(global_file), "r") as f:
+                for line in f:
+                    line = line.rstrip("\n\r")   # Strip newlines, but not whitespace (which is what rstrip() alone will do)
+
+                    data = line.split( chr(0x1d) )
+                    
+                    if len(data) > 1:
+                        self.ti_global[data[0]] = data[1]
+
+            f.close            
+            
 
         if action == 'W' or action == 'U' or action == 'T':   # Write!
             self.ti_vars[response] = ''  # Blank out our old response
@@ -87,15 +101,16 @@ class TipiVariable(object):
 
 
         elif action == 'T':    #   TX via TCP
-            if 'REMOTE_HOST' not in self.ti_vars or 'REMOTE_PORT' not in self.ti_vars:
+            if 'REMOTE_HOST' not in self.ti_global or 'REMOTE_PORT' not in self.ti_global:
                 return bytearray('0' + chr(0x1e) + "ERROR")
 
             self.ti_vars[response] = ''  # Blank out our old response
 
-            # listener on 9918 expects:
+            # Listener on 9918 expects:
             # prog_guid 
             # session_id
             # app_id
+            # context (Optional)
             # action
             # var
             # val
@@ -104,11 +119,11 @@ class TipiVariable(object):
             tmp = []
         
             try:
-                session_id = self.ti_vars['SESSION_ID']
+                session_id = self.ti_global['SESSION_ID']
             except:
                 session_id = ""
             
-            tmp = [str(caller_guid), session_id, str(caller_guid), str(action)]
+            tmp = [str(caller_guid), str(session_id), str(context), str(action)]
 
             if var_key1:
                 tmp.append(str(var_key1))
@@ -128,7 +143,7 @@ class TipiVariable(object):
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             
             try:
-                server_address = (self.ti_vars['REMOTE_HOST'], int(self.ti_vars['REMOTE_PORT']))
+                server_address = (self.ti_global['REMOTE_HOST'], int(self.ti_global['REMOTE_PORT']))
             except:
                 pass
 
@@ -160,7 +175,6 @@ class TipiVariable(object):
 
         elif action == 'R' or action == 'RS':   # Read!   'RS' is "READ SIMPLE" which will just return the value, not preceeded by return code. Better for BASIC!
             if str(var_key1) in self.ti_vars and len(str(self.ti_vars[str(var_key1)])):  # str() is necessary because var_key is an unhashable bytearray. If not forced to string: "TypeError: unhashable type: 'bytearray'"
-                
                 # Need to check to see if variable is queued, uses ASCII 31 (Unit Separator) to delimit.
                 # If so, we want to pop off the first one and return it.
                 if chr(0x1e) in str(self.ti_vars[str(var_key1)]):
@@ -200,6 +214,7 @@ class TipiVariable(object):
                 
 
     def store(self, caller_guid):
+    
         # Create runtime directory if it doesn't exist:
         if not os.path.exists(runtime_dir):
             try:
@@ -214,6 +229,7 @@ class TipiVariable(object):
         for key, val in self.ti_vars.items():
             if len(key):
                 f.write(key + chr(0x1d) + str(val) + "\n")
+
             
         f.close()        
 


### PR DESCRIPTION
Now supports a context for TipiNetvars. You can specify a context string when reading or writing variables, and they can be used to keep track of things like the name of a game for a given game's app_guid.

I also added support for GLOBAL variables for things that should persist across applications that use TipiNetvars, such as the SESSION_ID for staying logged in on myti99.com.


