### PR TITLE
Jm42/dsr cpu buffers

### DIFF
--- a/hardware/dsr/devices.a99
+++ b/hardware/dsr/devices.a99
@@ -163,9 +163,13 @@ handlers			; 2x opcode + handlers is address to branch to.
 	DATA	retdone		; scratch opcode not implemented.
 	DATA	hstatus
 
+CPUFLAG
+	DATA  >4000
+
 hresponse
 	CLR	R1		; switch on opcode in R1
 	MOVB	@OPCODE(R10),@R1LB(R10)
+	SZCB	@CPUFLAG,@R1LB(R10)		; will need to remove cpu buffer bit if set
 	SLA	R1,1		; multiply by 2
 	AI	R1,handlers	; R1 now has address of handler reference
 	MOV	*R1,R1
@@ -192,8 +196,13 @@ hclose
 hread
 	MOV	@RECNUM(R10),R0
 	MOV	@BUFADR(R10),R1
-	BL	@vrecvmsg	; R0 is now number of bytes read in record
-	SWPB	R0
+	MOV	@OPCODE(R10),R9
+	COC	@CPUFLAG,R9	; If the cpuflag is set, set equal status bit
+	JEQ	!
+	BL	@vrecvmsg	; Read into VDP buffer, R0 has num bytes read
+	JMP !!
+!	BL	@recvmsg	; Read into CPU buffer, R0 has num bytes read
+!	SWPB	R0
 	MOV	@VPAB,R3
 	AI	R3,CHRCNT-OPCODE
 	.setvdpwa R3
@@ -228,9 +237,14 @@ wrrel
 finwrite
 	SWPB	R0
 	MOV	@BUFADR(R10),R1
-	BL	@vsendmsg
-	
-	LI	R0,1		; Set expectation to read 1 byte
+; If @OPCODE(R10) has CPU buffer bit set then use sendmsg instead of vsendmsg
+	MOV	@OPCODE(R10),R9
+	COC @CPUFLAG,R9	; If the cpuflag is set, set equal status bit
+	JEQ	!
+	BL	@vsendmsg	; write record from VDP ram
+	JMP !!
+!	BL	@sendmsg	; write record from CPU ram
+!	LI	R0,1		; Set expectation to read 1 byte
 	MOV	R10,R1		; Set receive address to Workspace
 	AI	R1,R9LB		; add low byte address of R9 to receive address
 	CLR	R9		; clear value in R9 so MSB is 0.
@@ -250,16 +264,25 @@ hrestore
 hload
 	MOV	@RECNUM(R10),R0	; VPD space left is limited
 	MOV	@BUFADR(R10),R1	; Set VDP location to load in to.
-	BL	@vrecvmsg 	; Load image data
-	JMP	retdone
+	MOV	@OPCODE(R10),R9
+	COC	@CPUFLAG,R9	; If the cpuflag is set, set equal status bit
+	JEQ	!
+	BL	@vrecvmsg 	; Load image data into VDP ram
+	JMP	!!
+!	BL	@recvmsg	; Load image data into CPU ram
+!	JMP	retdone
 
 ; Handle response for OPCODE 6 - OPSAVE
 hsave
 	MOV	@RECNUM(R10),R0
 	MOV	@BUFADR(R10),R1
-	BL	@vsendmsg
-
-	LI	R0,1		; Set expectation to read 1 byte
+	MOV	@OPCODE(R10),R9
+	COC	@CPUFLAG,R9	; If the cpuflag is set, set equal status bit
+	JEQ	!
+	BL	@vsendmsg	; save data from VDP ram
+	JMP	!!
+!	BL	@sendmsg	; save data from CPU ram
+!	LI	R0,1		; Set expectation to read 1 byte
 	MOV	R10,R1		; Set receive address to Workspace
 	AI	R1,R9LB		; add low byte address of R9 to receive address
 	CLR	R9		; clear value in R9 so MSB is 0.

--- a/hardware/dsr/devices.a99
+++ b/hardware/dsr/devices.a99
@@ -73,6 +73,22 @@ cleanup
 	MOVB	R0,@TCOUT
 	RT
 
+; uses R9
+dcvsend				; examine opcode for cpuflag, and delegate to vdp or cpu send function
+	MOV	@OPCODE(R10),R9
+	COC @CPUFLAG,R9	; If the cpuflag is set, set equal status bit
+	JEQ	!
+	B	@vsendmsg	; write data from VDP ram
+!	B	@sendmsg	; write data from CPU ram
+
+; uses R9
+dcvrecv				; examine opcode for cpuflag, and delegate to vdp or cpu recv function
+	MOV	@OPCODE(R10),R9
+	COC @CPUFLAG,R9	; If the cpuflag is set, set equal status bit
+	JEQ	!
+	B	@vrecvmsg	; read data from VDP ram
+!	B	@recvmsg	; read data from CPU ram
+
 ; Handle requests to TIPI device
 tipidsr
 	LIMI	0		; I/O plays with VDP registers and relies on them
@@ -101,7 +117,10 @@ tipidsr
 	LI	R0,>0A		; PAB is 10 bytes
 	MOV	R10,R1
 	AI	R1,OPCODE
+	SZCB	@CPUFLAG,@OPCODE(R10)	; clear cpuflag before sending pab to TIPI
 	BL	@sendmsg	; send the 10 byte PAB from scratchpad
+	.setvdpra 	R9
+	MOVB	@VDPRD,@OPCODE(R10)		; restore original opcode from VDP
 
 	MOV	@PABNAM,R1	; Begin computing beginning of PAB device name
 	S	@PABNLE,R1	;   rewind to beginning of device name (might need to only consume the LSB of PABNLE
@@ -196,13 +215,8 @@ hclose
 hread
 	MOV	@RECNUM(R10),R0
 	MOV	@BUFADR(R10),R1
-	MOV	@OPCODE(R10),R9
-	COC	@CPUFLAG,R9	; If the cpuflag is set, set equal status bit
-	JEQ	!
-	BL	@vrecvmsg	; Read into VDP buffer, R0 has num bytes read
-	JMP !!
-!	BL	@recvmsg	; Read into CPU buffer, R0 has num bytes read
-!	SWPB	R0
+	BL	@dcvrecv	; Read into buffer, R0 has num bytes read
+	SWPB	R0
 	MOV	@VPAB,R3
 	AI	R3,CHRCNT-OPCODE
 	.setvdpwa R3
@@ -237,14 +251,8 @@ wrrel
 finwrite
 	SWPB	R0
 	MOV	@BUFADR(R10),R1
-; If @OPCODE(R10) has CPU buffer bit set then use sendmsg instead of vsendmsg
-	MOV	@OPCODE(R10),R9
-	COC @CPUFLAG,R9	; If the cpuflag is set, set equal status bit
-	JEQ	!
-	BL	@vsendmsg	; write record from VDP ram
-	JMP !!
-!	BL	@sendmsg	; write record from CPU ram
-!	LI	R0,1		; Set expectation to read 1 byte
+	BL	@dcvsend	; write record from buffer
+	LI	R0,1		; Set expectation to read 1 byte
 	MOV	R10,R1		; Set receive address to Workspace
 	AI	R1,R9LB		; add low byte address of R9 to receive address
 	CLR	R9		; clear value in R9 so MSB is 0.
@@ -264,25 +272,15 @@ hrestore
 hload
 	MOV	@RECNUM(R10),R0	; VPD space left is limited
 	MOV	@BUFADR(R10),R1	; Set VDP location to load in to.
-	MOV	@OPCODE(R10),R9
-	COC	@CPUFLAG,R9	; If the cpuflag is set, set equal status bit
-	JEQ	!
-	BL	@vrecvmsg 	; Load image data into VDP ram
-	JMP	!!
-!	BL	@recvmsg	; Load image data into CPU ram
-!	JMP	retdone
+	BL	@dcvrecv	; Load image data into cpu or vdp ram
+	JMP	retdone
 
 ; Handle response for OPCODE 6 - OPSAVE
 hsave
 	MOV	@RECNUM(R10),R0
 	MOV	@BUFADR(R10),R1
-	MOV	@OPCODE(R10),R9
-	COC	@CPUFLAG,R9	; If the cpuflag is set, set equal status bit
-	JEQ	!
-	BL	@vsendmsg	; save data from VDP ram
-	JMP	!!
-!	BL	@sendmsg	; save data from CPU ram
-!	LI	R0,1		; Set expectation to read 1 byte
+	BL	@dcvsend	; save data from CPU ram
+	LI	R0,1		; Set expectation to read 1 byte
 	MOV	R10,R1		; Set receive address to Workspace
 	AI	R1,R9LB		; add low byte address of R9 to receive address
 	CLR	R9		; clear value in R9 so MSB is 0.

--- a/hardware/dsr/header.a99
+++ b/hardware/dsr/header.a99
@@ -1,10 +1,10 @@
 ; DSR ROM header
 	AORG >4000
 
-	BYTE	>AA		; Standard Header
-        BYTE	>01		; version
-        DATA	>0000		; # of application programs / reserved
-        DATA	pwrlnk		; power up list
+	BYTE	>AA			; Standard Header
+	BYTE	>03			; version
+	DATA	>0000		; # of application programs / reserved
+	DATA	pwrlnk		; power up list
 	DATA	>0000		; user-program list (grom only)
 	DATA	tipilnk		; DSR list
 	DATA	basiclnk	; LVL2 DSRLNK & BASIC CALL subroutine list
@@ -14,7 +14,7 @@
 ; TIPI routine list - well known addresses for some custom exposure
 	DATA	recvmsg		; MOV @>4010,R0   BL *R0   to invoke recvmsg.
 	DATA	sendmsg		; MOV @>4012,R0   BL *R0   to invoke sendmsg. 
-	DATA	vrecvmsg	; MOV @>4014,R0   BL *R0   to invoke recvmsg.
-	DATA	vsendmsg	; MOV @>4016,R0   BL *R0   to invoke sendmsg. 
+	DATA	vrecvmsg	; MOV @>4014,R0   BL *R0   to invoke vrecvmsg.
+	DATA	vsendmsg	; MOV @>4016,R0   BL *R0   to invoke vsendmsg. 
 	DATA	>0000
 

--- a/hardware/dsr/level2.a99
+++ b/hardware/dsr/level2.a99
@@ -277,13 +277,20 @@ setpath				; set current directory for a unit/drive
 	LI	R0,1
 	BL	@cleanunit	; copy unitno and unset cpuflag, return address of R9 in R1
 	BL	@sendmsg	; send unit number
-	MOV	@PATHNAM,R1
+	; PATHNAME points to a BASIC STR ( len + bytes ), which complicates all this.
+	MOV	@PATHNAM,R1	; set R1 to len byte address of BASIC STR
+	CLR	R0		; zero out R0 before copying len byte into it
+	MOV	@UNITNO,R9
+	COC	@BUFFLAG,R9	; set equal bit if cpuflag requested
+	JEQ	!
 	.setvdpra R1
-	CLR	R0
-	MOVB	@VDPRD,R0
-	SWPB	R0		; get length of string
-	MOV	@PATHNAM,R1
-	INC	R1
+	MOVB	@VDPRD,R0	; get length of string from VDP basic string
+	JMP	!!		; now skip to adjustments of R0 and R1 and sending the message
+!	MOVB	*R1,R0		; copy length byte into R0
+
+	; Now finish sending the message
+!	SWPB	R0		; put length byte in LSB
+	INC	R1		; start sending from the characters, not the length byte
 	BL	@cvsend		; send path string
 	JMP	getl2resp
 

--- a/hardware/dsr/level2.a99
+++ b/hardware/dsr/level2.a99
@@ -49,14 +49,11 @@ L2STAT		EQU	>8350
 WOLDNAM		EQU	L2STAT		; (vdp addr) if two names are used, this is the original
 SECTORN 	EQU	L2STAT		; sector to read
 
-; Convenience
-GPLR0LB EQU >83E1
-GPLR9	EQU	>83F2
-
-cleanunit					; Modifies R9 and R1
-	MOV		@UNITNO,R9 		; Unit number in high byte of R9, bring along low byte as it is usually sent together in a 2 byte message
-	SZC		@BUFFLAG,R9 	; unset the cpuflag if it was set
-	LI		R1,GPLR9		; return address of clean unitno R9 in R1
+cleanunit			; Modifies R9 and R1
+	MOV	@UNITNO,R9 	; Unit number in high byte of R9, bring along low byte as it is usually sent together in a 2 byte message
+	SZC	@BUFFLAG,R9 	; unset the cpuflag if it was set
+	STWP	R1		; return address of clean unitno R9 in R1, first get WP into R1
+	AI	R1,18		;   then adjust to address of R9
 	RT
 
 ; Expects R0 to be bytes to send, R1 address of bytes to send (either VDP or CPU).
@@ -355,7 +352,8 @@ getl2resp
 	MOVB	@L2STAT,@L2STAT
 	JEQ	retl2sk		; PI didn't handled request
 	CLR	R0
-	MOVB	@L2STAT,@GPLR0LB
+	MOVB	@L2STAT,R0
+	SWPB	R0
 	CI	R0,SUCCESS
 	JEQ	l2suc
 	SRC	R0,3

--- a/hardware/dsr/level2.a99
+++ b/hardware/dsr/level2.a99
@@ -32,26 +32,50 @@ RDIR_MSG
 
 	EVEN
 
-; Error codes must go in >8350
-L2STAT	EQU	>8350
+BUFFLAG ; THIS LABEL NEEDS TO BE DIFFERENT TOO
+	DATA	>8000		; The high bit of a unit number in >834C indicates use of CPU buffers (instead of VDP)
 
-; Parameters
-BUFCNT	EQU	>834C
-
-; Common addresses
-UNITNO	EQU	>834C
-PROTVAL	EQU	>834D
-BLOCKCNT EQU	PROTVAL		; number of blocks to read/write
-WFILNAM	EQU	>834E		; (vdp addr) note, filenames are 10 characters... space padded in this context.
-WOLDNAM	EQU	>8350		; (vdp addr) if two names are used, this is the original
-PATHNAM EQU	WFILNAM		; (vdp addr) path name for set path operation.
-SECREAD EQU	>834A		; after reading a sector, the sector number ends up here
-SECTORN EQU	>8350		; sector to read
-READWRI	EQU	>834D		; sector operation mode, if 0 write, else read
-SECTBUF	EQU	>834E		; when performing sector contains VDP addr for 256 byte buffer
+; Common parameter and status addresses
+SECREAD 	EQU	>834A		; after reading a sector, the sector number ends up here
+UNITNO		EQU	>834C
+BUFCNT		EQU	UNITNO
+READWRI		EQU	>834D		; sector operation mode, if 0 write, else read
+PROTVAL		EQU	READWRI
+BLOCKCNT 	EQU	READWRI		; number of blocks to read/write
+WFILNAM		EQU	>834E		; (vdp addr) note, filenames are 10 characters... space padded in this context.
+SECTBUF		EQU	WFILNAM		; when performing sector contains VDP addr for 256 byte buffer
+PATHNAM 	EQU	WFILNAM		; (vdp addr) path name for set path operation.
+L2STAT		EQU	>8350
+WOLDNAM	EQU	L2STAT	; (vdp addr) if two names are used, this is the original
+SECTORN 	EQU	L2STAT		; sector to read
 
 ; Convenience
 GPLR0LB EQU >83E1
+GPLR9	EQU	>83F2
+
+cleanunit					; Modifies R9 and R1
+	MOVB	@UNITNO,R9 		; Unit number in high by of R9
+	SZC		@BUFFLAG,R9 	; unset the cpuflag if it was set
+	LI		R1,GPLR9		; return address of clean unitno R9 in R1
+	RT
+
+; Expects R0 to be bytes to send, R1 address of bytes to send (either VDP or CPU).
+; examines UNITNO for set cpuflag, and chooses vsendmsg or sendmsg
+cvsend
+	MOV	@UNITNO,R9
+	COC	@BUFFLAG,R9	; set equal bit if cpuflag requested
+	JEQ	!
+	B	@vsendmsg	; send from vdp buffer
+!	B	@sendmsg	; send from cpu buffer
+
+; Expects R0 to be bytes to send, R1 address of bytes to send (either VDP or CPU).
+; examines UNITNO for set CPUFLAG, and chooses vsendmsg or sendmsg
+cvrecv
+	MOV	@UNITNO,R9
+	COC	@BUFFLAG,R9	; set equal bit if cpuflag requested
+	JEQ	!
+	B	@vrecvmsg	; read from vdp buffer
+!	B	@recvmsg	; read from cpu buffer
 
 sector				; Read a sector from a synthesized disk, error on write
 	LIMI	0
@@ -60,7 +84,7 @@ sector				; Read a sector from a synthesized disk, error on write
 	LI	R1,SECT_MSG
 	BL	@sendmsg	; send sector request type
 	LI	R0,2
-	LI	R1,UNITNO
+	BL	@cleanunit	; copy unitno to R9, and unset cpuflag, return address of R9 in R1
 	BL	@sendmsg	; send unit number and read/write flag
 	LI	R0,2
 	LI	R1,SECTORN
@@ -86,14 +110,14 @@ sectcont
 sectread
 	LI	R0,256		; this is actually ignored. set maximum bytes to read
 	MOV	@SECTBUF,R1
-	BL	@vrecvmsg	; read single sector into vdp buffer
+	BL	@cvrecv	; read single sector into cpu or vdp buffer
 	CLR	@L2STAT		; set no error
 	B	@l2derr		; return as handled
 
 sectwri
 	LI	R0,256		; this is actually ignored. set maximum bytes to read
 	MOV	@SECTBUF,R1
-	BL	@vsendmsg	; write single sector from vdp buffer to TIPI
+	BL	@cvsend	; write single sector from vdp or cpu buffer to TIPI
 	CLR	@L2STAT		; set no error
 	B	@l2derr
 
@@ -104,11 +128,11 @@ protect				; Set or unset protect bit on a file
 	LI	R1,PROT_MSG
 	BL	@sendmsg	; send protect file request type
 	LI	R0,2
-	LI	R1,UNITNO
+	BL	@cleanunit	; copy unitno to R9, and unset cpuflag, return address of R9 in R1
 	BL	@sendmsg	; send unit number and protect value
 	LI	R0,10
 	MOV	@WFILNAM,R1
-	BL	@vsendmsg	; send filename to modify
+	BL	@cvsend	; send filename to modify
 	B	@getl2resp
 
 frename				; rename a file on a device in the current path
@@ -118,14 +142,14 @@ frename				; rename a file on a device in the current path
 	LI	R1,FREN_MSG
 	BL	@sendmsg	; send rename request header
 	LI	R0,1
-	LI	R1,UNITNO
+	BL	@cleanunit	; copy unitno to R9, and unset cpuflag, return address of R9 in R1
 	BL	@sendmsg	; send unit number
 	LI	R0,10
 	MOV	@WFILNAM,R1
-	BL	@vsendmsg	; send new filename
+	BL	@cvsend		; send new filename
 	LI	R0,10
 	MOV	@WOLDNAM,R1
-	BL	@vsendmsg	; send old filename
+	BL	@cvsend		; send old filename
 	B	@getl2resp
 
 directinp			; read file bytes
@@ -135,11 +159,11 @@ directinp			; read file bytes
 	LI	R1,DINP_MSG
 	BL	@sendmsg	; send direct input header
 	LI	R0,2
-	LI	R1,UNITNO
+	BL	@cleanunit	; copy unitno & number of blocks word to R9, and unset cpuflag, return address of R9 in R1
 	BL	@sendmsg	; send unit number and number of blocks to read
 	LI	R0,10
 	MOV	@WFILNAM,R1
-	BL	@vsendmsg	; send name of file to read
+	BL	@cvsend		; send name of file to read
 	CLR	R8
 	MOVB	@L2STAT,R8
 	SWPB	R8
@@ -178,7 +202,7 @@ disuc
 
 	LI	R0,256		; this is actually ignored. set maximum bytes to read
 	MOV	*R8,R1
-	BL	@vrecvmsg	; read blocks into vdp buffer
+	BL	@cvrecv	; read blocks into buffer
 	JMP	l2derr		; return as handled
 
 directout			; write file bytes
@@ -188,11 +212,11 @@ directout			; write file bytes
 	LI	R1,DOUT_MSG
 	BL	@sendmsg	; send direct output header
 	LI	R0,2
-	LI	R1,UNITNO
+	BL	@cleanunit	; copy unitno & number of blocks word to R9, and unset cpuflag, return address of R9 in R1
 	BL	@sendmsg	; send unit number and number of blocks to write
 	LI	R0,10
 	MOV	@WFILNAM,R1
-	BL	@vsendmsg	; send name of file to write
+	BL	@cvsend		; send name of file to write
 	CLR	R8
 	MOVB	@L2STAT,R8
 	SWPB	R8
@@ -219,7 +243,7 @@ dosuc
 	MOVB	@BLOCKCNT,R0	; block count * 256 ( by being in the MSB )
 	JEQ	l2done		; skip sending blocks if block count was 0
 	MOV	*R8,R1
-	BL	@vsendmsg	; send the data blocks
+	BL	@cvsend		; send the data blocks
 
 	LI	R0,1
 	LI	R1,L2STAT
@@ -251,7 +275,7 @@ setpath				; set current directory for a unit/drive
 	LI	R1,PATH_MSG
 	BL	@sendmsg	; send set path request header
 	LI	R0,1
-	LI	R1,UNITNO
+	BL	@cleanunit	; copy unitno and unset cpuflag, return address of R9 in R1
 	BL	@sendmsg	; send unit number
 	MOV	@PATHNAM,R1
 	.setvdpra R1
@@ -260,7 +284,7 @@ setpath				; set current directory for a unit/drive
 	SWPB	R0		; get length of string
 	MOV	@PATHNAM,R1
 	INC	R1
-	BL	@vsendmsg	; send path string
+	BL	@cvsend		; send path string
 	JMP	getl2resp
 
 createdir			; create a subdirectory
@@ -270,11 +294,11 @@ createdir			; create a subdirectory
 	LI	R1,CDIR_MSG
 	BL	@sendmsg	; send set path request header
 	LI	R0,1
-	LI	R1,UNITNO
+	BL	@cleanunit	; copy unitno and unset cpuflag, return address of R9 in R1
 	BL	@sendmsg	; send unit number
 	LI	R0,10
 	MOV	@WFILNAM,R1
-	BL	@vsendmsg	; send new directory name
+	BL	@cvsend		; send new directory name
 	JMP	getl2resp
 
 deldir				; delete a directory
@@ -284,11 +308,11 @@ deldir				; delete a directory
 	LI	R1,DDIR_MSG
 	BL	@sendmsg	; send set path request header
 	LI	R0,1
-	LI	R1,UNITNO
+	BL	@cleanunit	; copy unitno and unset cpuflag, return address of R9 in R1
 	BL	@sendmsg	; send unit number
 	LI	R0,10
 	MOV	@WFILNAM,R1
-	BL	@vsendmsg	; send new directory name
+	BL	@cvsend		; send directory name to delete
 	JMP	getl2resp
 
 drename				; directory rename
@@ -298,14 +322,14 @@ drename				; directory rename
 	LI	R1,RDIR_MSG
 	BL	@sendmsg	; send rename request header
 	LI	R0,1
-	LI	R1,UNITNO
+	BL	@cleanunit	; copy unitno and unset cpuflag, return address of R9 in R1
 	BL	@sendmsg	; send unit number
 	LI	R0,10
 	MOV	@WFILNAM,R1
-	BL	@vsendmsg	; send new name
+	BL	@cvsend		; send new name
 	LI	R0,10
 	MOV	@WOLDNAM,R1
-	BL	@vsendmsg	; send old name
+	BL	@cvsend		; send old name
 	JMP	getl2resp
 
 retl2err

--- a/hardware/dsr/level2.a99
+++ b/hardware/dsr/level2.a99
@@ -54,7 +54,7 @@ GPLR0LB EQU >83E1
 GPLR9	EQU	>83F2
 
 cleanunit					; Modifies R9 and R1
-	MOVB	@UNITNO,R9 		; Unit number in high by of R9
+	MOV		@UNITNO,R9 		; Unit number in high byte of R9, bring along low byte as it is usually sent together in a 2 byte message
 	SZC		@BUFFLAG,R9 	; unset the cpuflag if it was set
 	LI		R1,GPLR9		; return address of clean unitno R9 in R1
 	RT

--- a/hardware/dsr/level2.a99
+++ b/hardware/dsr/level2.a99
@@ -46,7 +46,7 @@ WFILNAM		EQU	>834E		; (vdp addr) note, filenames are 10 characters... space padd
 SECTBUF		EQU	WFILNAM		; when performing sector contains VDP addr for 256 byte buffer
 PATHNAM 	EQU	WFILNAM		; (vdp addr) path name for set path operation.
 L2STAT		EQU	>8350
-WOLDNAM	EQU	L2STAT	; (vdp addr) if two names are used, this is the original
+WOLDNAM		EQU	L2STAT		; (vdp addr) if two names are used, this is the original
 SECTORN 	EQU	L2STAT		; sector to read
 
 ; Convenience
@@ -110,14 +110,14 @@ sectcont
 sectread
 	LI	R0,256		; this is actually ignored. set maximum bytes to read
 	MOV	@SECTBUF,R1
-	BL	@cvrecv	; read single sector into cpu or vdp buffer
+	BL	@cvrecv		; read single sector into cpu or vdp buffer
 	CLR	@L2STAT		; set no error
 	B	@l2derr		; return as handled
 
 sectwri
-	LI	R0,256		; this is actually ignored. set maximum bytes to read
+	LI	R0,256		; set byte count to write
 	MOV	@SECTBUF,R1
-	BL	@cvsend	; write single sector from vdp or cpu buffer to TIPI
+	BL	@cvsend		; write single sector from vdp or cpu buffer to TIPI
 	CLR	@L2STAT		; set no error
 	B	@l2derr
 

--- a/hardware/dsr/tipi-io.a99
+++ b/hardware/dsr/tipi-io.a99
@@ -103,7 +103,7 @@ vsdone
 ; Register usage:
 ;   R0 - Set to number of bytes loaded into buffer upon completion
 ;   R1 - cpu address of buffer
-;   Destroys R0 - R8
+;   Destroys R0 - R4
 recvmsg
 	.reset			; conduct the handshake operation
 	LI	R2,TSRB		; set read mode


### PR DESCRIPTION
changes to support cpu buffers per the myarc HFDC 4th edition spec. 

PABs in cpu are not supported. 
File names, directory paths, and block buffers are supported for LVL2 (low level file management) and LVL1 (sector) io routines
Read and Write buffers are supported for PAB based LVL3 ( PAB w/opcode ) routines.