### PR TITLE
fix code label at odd address

### DIFF
--- a/hardware/dsr/basic.a99
+++ b/hardware/dsr/basic.a99
@@ -3,6 +3,7 @@ GPLWS	EQU	>83E0
 
 TIPICFG	BYTE	12
 	TEXT	"TIPI.TIPICFG"
+	EVEN
 
 btipicfg			; implementation of CALL TIPI
 	LIMI	0


### PR DESCRIPTION
Since `TIPICG` is an odd number of bytes (13), the `EVEN` is needed or the label `btipicfg` will end up at `>4C19` instead of `>4C1A`, which in turn will cause a jump to `>4C18` (LSB of PC is ignored) which executes the bogus instruction `SZC R0,*R12`.  Probably harmless, but also not intended I guess...  :smile: